### PR TITLE
Make hdf5-to-idx more robust.

### DIFF
--- a/examples/convert/hdf5-to-idx.c
+++ b/examples/convert/hdf5-to-idx.c
@@ -17,359 +17,506 @@
  *****************************************************/
 
 #include <PIDX.h>
-#include "hdf5.h"
+#include <hdf5.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #if PIDX_HAVE_MPI
-  #include <mpi.h>
+#include <mpi.h>
 #endif
 
-#define PIDX_IO 1
 #define HDF5_IO 1
+#define USE_DOUBLE
+#define PIDX_ROW_OR_COLUMN_MAJOR PIDX_row_major
 
-static int parse_args(int argc, char **argv);
-static void usage(void);
-#if PIDX_IO
-static void report_error(char* func_name, char* file_name, int line_no);
-#endif
-static void delete_buffers();
-
-static unsigned long long global_box_size[3] = {0, 0, 0};            ///< global dimensions of 3D volume
-static unsigned long long local_box_size[3] = {0, 0, 0};             ///< local dimensions of the per-process block
-static int time_step_count = 1;                       ///< Number of time-steps
-static int variable_count = 1;                        ///< Number of fields
-static char **var_name;
-static char output_file_template[512] = "test_idx";   ///< output IDX file Name Template
+enum { X, Y, Z, NUM_DIMS };
+enum AtomicType { CHAR = 1, INT = 4, FLOAT = 4, DOUBLE = 8, INVALID };
+struct Type
+{
+  enum AtomicType atomic_type;
+  unsigned long long num_values;
+};
+static unsigned long long global_box_size[NUM_DIMS] = { 0 }; ///< global dimensions of 3D volume
+static unsigned long long local_box_size[NUM_DIMS] = { 0 }; ///< local dimensions of the per-process block
+static unsigned long long local_box_offset[NUM_DIMS] = { 0 };
+static PIDX_point pidx_global_box_size = { 0 };
+static PIDX_point pidx_local_box_offset = { 0 };
+static PIDX_point pidx_local_box_size = { 0 };
+static int process_count = 1; ///< Number of processes
+static int rank = 0;
+static int time_step_count = 1; ///< Number of time-steps
+static int var_count = 1; ///< Number of fields
+static char output_file_template[512] = "test"; ///< output IDX file Name Template
+static char output_file_name[512] = "test.idx";
 static char var_file[512];
-static char input_file[512];
-static char **file_name;
-static double **buffer;
-static int *values_per_sample;    // Example: 1 for scalar 3 for vector
+static char hdf5_file_list[512];
+static char **var_names = 0;
+static char **hdf5_file_names = 0;
+static struct Type *var_types = 0;
+static PIDX_variable *pidx_vars = 0;
+static void *var_data = 0;
 
-int main(int argc, char **argv)
+static char *usage = "Serial Usage: ./hdf5-to-idx -g 4x4x4 -l 4x4x4 -v var_list -i hdf5_file_names_list -f output_idx_file_name\n"
+                     "Parallel Usage: mpirun -n 8 ./hdf5-to-idx -g 4x4x4 -l 2x2x2 -f Filename_ -v var_list -i hdf5_file_names_list\n"
+                     "  -g: global dimensions\n"
+                     "  -l: local (per-process) dimensions\n"
+                     "  -f: IDX filename\n"
+                     "  -i: file containing list of input hdf5 files\n"
+                     "  -v: file containing list of input fields\n";
+
+//----------------------------------------------------------------
+// TODO: write another function to release resources before terminating
+static void terminate()
 {
-  int ret;
-  int t;
-  int var;
-  int slice = 0;
-  int nprocs = 1, rank = 0;
-  char output_file_name[1024];
-  unsigned long long local_box_offset[3];
-
-  // MPI initialization
-#if PIDX_HAVE_MPI
-  MPI_Init(&argc, &argv);
-  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-#endif
-
-  ret = parse_args(argc, argv);
-  if (ret < 0)
-  {
-    usage();
-#if PIDX_HAVE_MPI
-    MPI_Abort(MPI_COMM_WORLD, -1);
-#else
-    exit(-1);
-#endif
-  }
-
-  // check if the num procs is appropriate
-  int num_bricks = (global_box_size[0] / local_box_size[0]) * (global_box_size[1] / local_box_size[1]) * (global_box_size[2] / local_box_size[2]);
-
-  if(num_bricks != nprocs)
-  {
-    fprintf(stderr, "Error: number of sub-blocks (%d) doesn't match number of procs (%d)\n", num_bricks, nprocs);
-    fprintf(stderr, "Incorrect distribution of data across processes i.e.\n(global_x / local_x) X (global_x / local_x) X (global_x / local_x) != nprocs\n(%d/%d) X (%d/%d) X (%d/%d) != %d\n", (int)global_box_size[0], (int)local_box_size[0], (int)global_box_size[1], (int)local_box_size[1], (int)global_box_size[2], (int)local_box_size[2], nprocs);
-
-#if PIDX_HAVE_MPI
-    MPI_Abort(MPI_COMM_WORLD, -1);
-#else
-    exit(-1);
-#endif
-  }
-
-  // Creating the filename
-  sprintf(output_file_name, "%s%s", output_file_template,".idx");
-
-  // Calculating every process data's offset and size
-  int sub_div[3];
-  sub_div[0] = (global_box_size[0] / local_box_size[0]);
-  sub_div[1] = (global_box_size[1] / local_box_size[1]);
-  sub_div[2] = (global_box_size[2] / local_box_size[2]);
-  local_box_offset[2] = (rank / (sub_div[0] * sub_div[1])) * local_box_size[2];
-  slice = rank % (sub_div[0] * sub_div[1]);
-  local_box_offset[1] = (slice / sub_div[0]) * local_box_size[1];
-  local_box_offset[0] = (slice % sub_div[0]) * local_box_size[0];
-#if HDF5_IO
-  hid_t file_id, plist_id, dataset_id;
-  hid_t file_dataspace, mem_dataspace;
-#endif
-
-#if PIDX_IO
-  PIDX_point global_bounding_box, local_offset, local_size;
-  PIDX_set_point_5D(global_bounding_box, global_box_size[0], global_box_size[1], global_box_size[2], 1, 1);
-  PIDX_set_point_5D(local_offset, local_box_offset[0], local_box_offset[1], local_box_offset[2], 0, 0);
-  PIDX_set_point_5D(local_size, local_box_size[0], local_box_size[1], local_box_size[2], 1, 1);
-
-  PIDX_file file;
-  PIDX_access access;
-  PIDX_variable *variable;
-#endif
-
-#if PIDX_IO
-  PIDX_create_access(&access);
-
-#if PIDX_HAVE_MPI
-  PIDX_set_mpi_access(access, MPI_COMM_WORLD);
-#endif
-#endif
-
-#if HDF5_IO
-  plist_id = H5Pcreate(H5P_FILE_ACCESS);
-
-#if PIDX_HAVE_MPI
-  H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
-#endif
-#endif
-
-#if PIDX_IO
-  PIDX_time_step_caching_ON();
-#endif
-  for (t = 0; t < time_step_count; t++)
-  {
-#if HDF5_IO
-    file_id = H5Fopen(file_name[t], H5F_ACC_RDONLY, plist_id);
-    for(var = 0; var < variable_count; var++)
-    {
-      memset(buffer[var], 0, sizeof(double) * local_box_size[0] * local_box_size[1] * local_box_size[2]);
-      dataset_id = H5Dopen2(file_id, var_name[var], H5P_DEFAULT);
-
-      mem_dataspace = H5Screate_simple (3, local_box_size, NULL);
-      file_dataspace = H5Dget_space (dataset_id);
-      H5Sselect_hyperslab(file_dataspace, H5S_SELECT_SET, local_box_offset, NULL, local_box_size, NULL);
-
-      H5Dread(dataset_id, H5T_NATIVE_DOUBLE, mem_dataspace, file_dataspace, H5P_DEFAULT, buffer[var]);
-
-      H5Sclose(mem_dataspace);
-      H5Sclose(file_dataspace);
-      H5Dclose(dataset_id);
-    }
-    H5Fclose(file_id);
-#endif
-
-#if PIDX_IO
-    variable = malloc(sizeof(*variable) * variable_count);
-    memset(variable, 0, sizeof(*variable) * variable_count);
-    PIDX_file_create(output_file_name, PIDX_file_trunc, access, &file);
-    PIDX_set_variable_count(file, variable_count);
-    PIDX_set_dims(file, global_bounding_box);
-    PIDX_set_current_time_step(file, t);
-    for(var = 0; var < variable_count; var++)
-    {
-      ret = PIDX_variable_create(var_name[var], sizeof(double) * 8, "1*float64", &variable[var]);
-      if (ret != PIDX_success)  report_error("PIDX_variable_data_layout", __FILE__, __LINE__);
-
-      ret = PIDX_variable_data_layout(variable[var], local_offset, local_size, buffer[var], PIDX_column_major);
-      if (ret != PIDX_success)  report_error("PIDX_variable_data_layout", __FILE__, __LINE__);
-
-      ret = PIDX_append_and_write_variable(file, variable[var]);
-      if (ret != PIDX_success)  report_error("PIDX_append_and_write_variable", __FILE__, __LINE__);
-    }
-    PIDX_close(file);
-    free(variable);
-#endif
-
-  }
-#if PIDX_IO
-  PIDX_time_step_caching_OFF();
-#endif
-
-#if HDF5_IO
-  H5Pclose(plist_id);
-#endif
-
-#if PIDX_IO
-  PIDX_close_access(access);
-#endif
-
-  delete_buffers();
-
-#if PIDX_HAVE_MPI
-  MPI_Finalize();
-#endif
-
-  return 0;
-}
-
-static void delete_buffers()
-{
-  int i;
-
-  for (i = 0; i < variable_count; i++)
-  {
-    free(buffer[i]);
-    buffer[i] = 0;
-  }
-  free(buffer);
-  buffer = 0;
-
-  free(values_per_sample);
-  values_per_sample = 0;
-
-  for (i = 0; i < variable_count; i++)
-  {
-    free(var_name[i]);
-    var_name[i] = 0;
-  }
-  free(var_name);
-  var_name = 0;
-
-  for (i = 0; i < time_step_count; i++)
-  {
-    free(file_name[i]);
-    file_name[i] = 0;
-  }
-  free(file_name);
-  file_name = 0;
-
-  return;
-}
-
-///< Parse the input arguments
-static int parse_args(int argc, char **argv)
-{
-  int ret, i;
-  char flags[] = "g:l:f:i:v:";
-  int one_opt = 0;
-
-  while ((one_opt = getopt(argc, argv, flags)) != EOF)
-  {
-    /* postpone error checking for after while loop */
-    switch (one_opt)
-    {
-      case('g'):
-          sscanf(optarg, "%lldx%lldx%lld", &global_box_size[0], &global_box_size[1], &global_box_size[2]);
-          break;
-      case('l'):
-          sscanf(optarg, "%lldx%lldx%lld", &local_box_size[0], &local_box_size[1], &local_box_size[2]);
-          break;
-      case('f'):
-          sprintf(output_file_template, "%s", optarg);
-          break;
-      case('i'):
-          sprintf(input_file, "%s", optarg);
-          break;
-      case('v'):
-          sprintf(var_file, "%s", optarg);
-          break;
-      case('?'):
-          return (-1);
-    }
-  }
-    /* need positive dimensions */
-  if (global_box_size[0] < 1 || global_box_size[1] < 1 || global_box_size[2] < 1 || local_box_size[0] < 1 || local_box_size[1] < 1 || local_box_size[2] < 1)
-  {
-    fprintf(stderr, "Error: bad dimension specification.\n");
-    return (-1);
-  }
-
-  /* need global dimension to be larger than the local */
-  if (global_box_size[0] < local_box_size[0] || global_box_size[1] < local_box_size[1] || global_box_size[2] < local_box_size[2])
-  {
-    fprintf(stderr, "Error: Per-process local box size cannot be greater than the global box\n");
-    return (-1);
-  }
-
-  if (local_box_size[0] == 0 || local_box_size[1] == 0 || local_box_size[2] == 0)
-  {
-    fprintf(stderr, "Local Dimension cannot be 0!!!!!!!!!\n");
-    return (-1);
-  }
-
-  if (global_box_size[0] == 0 || global_box_size[1] == 0 || global_box_size[2] == 0)
-  {
-    fprintf(stderr, "Global Dimension cannot be 0!!!!!!!!!\n");
-    return (-1);
-  }
-
-  FILE *fp = fopen(var_file, "r");
-  ret = fscanf(fp, "%d", &variable_count);
-  if (ret != EOF && ret != 1)
-    return (-1);
-
-  var_name = malloc(sizeof(char*) * variable_count);
-  memset(var_name, 0, sizeof(char*) * variable_count);
-
-  buffer = malloc(sizeof(double*) * variable_count);
-  memset(buffer, 0, sizeof(double*) * variable_count);
-  for (i = 0; i < variable_count; i++)
-  {
-    buffer[i] = malloc(sizeof(double) * local_box_size[0] * local_box_size[1] * local_box_size[2]);
-    memset(buffer[i], 0, sizeof(double) * local_box_size[0] * local_box_size[1] * local_box_size[2]);
-  }
-
-  values_per_sample = malloc(sizeof(*values_per_sample) * variable_count);
-  memset(values_per_sample, 0, sizeof(*values_per_sample) * variable_count);
-
-  for (i = 0; i < variable_count; i++)
-  {
-    char temp_var_name[1024];
-    ret = fscanf(fp, "%s %d", temp_var_name, &values_per_sample[i]);
-    if (ret != 2 || ret == EOF)
-      return (-1);
-    var_name[i] = strdup(temp_var_name);
-  }
-  fclose(fp);
-
-
-  fp = fopen(input_file, "r");
-  ret = fscanf(fp, "%d", &time_step_count);
-  if (ret != EOF && ret != 1)
-    return (-1);
-  file_name = malloc(sizeof(char*) * time_step_count);
-  memset(file_name, 0, sizeof(char*) * time_step_count);
-
-  for (i = 0; i < time_step_count; i++)
-  {
-    char temp_file_name[1024];
-    ret = fscanf(fp, "%s", temp_file_name);
-    if (ret != 1 || ret == EOF)
-      return (-1);
-    file_name[i] = strdup(temp_file_name);
-  }
-  fclose(fp);
-
-  return (0);
-}
-
-
-///< How to use this progam
-static void usage(void)
-{
-  printf("Serial Usage: ./hdf5-to-idx -g 4x4x4 -l 4x4x4 -v var_list -i input_file_list -f output_idx_file_name\n");
-  printf("Parallel Usage: mpirun -n 8 ./hdf5-to-idx -g 4x4x4 -l 2x2x2 -f Filename_ -t 1 -v 1\n");
-  printf("  -g: global dimensions\n");
-  printf("  -l: local (per-process) dimensions\n");
-  printf("  -f: IDX Filename\n");
-  printf("  -i: list of input\n");
-  printf("  -v: list of input fields\n");
-
-  //printf("pidx-s3d-checkpoint generates a 3D volume of size g_x g_y g_z specified by -g command line parameter\nEach process writes a sub-volume of size l_x l_y l_z specified by -l command line parameter. \nData is written in the idx format, with the filename Filename specified by -f command line parameter. \nThe number of time-steps and the number of fields can be optionally provided by -t and -v command line parameters.\n");
-
-  printf("\n");
-
-  return;
-}
-
-#if PIDX_IO
-///< Print error and exit program
-static void report_error(char* func_name, char* file_name, int line_no)
-{
-  fprintf(stderr, "Error in function %s Program %s Line %d\n", func_name, file_name, line_no);
 #if PIDX_HAVE_MPI
   MPI_Abort(MPI_COMM_WORLD, -1);
 #else
   exit(-1);
 #endif
 }
+
+//----------------------------------------------------------------
+static void terminate_with_error_msg(const char *format, ...)
+{
+  va_list arg_ptr;
+  va_start(arg_ptr, format);
+  vfprintf(stderr, format, arg_ptr);
+  va_end(arg_ptr);
+  terminate();
+}
+
+//----------------------------------------------------------------
+static void rank_0_print(const char *format, ...)
+{
+  if (rank != 0) return;
+  va_list arg_ptr;
+  va_start(arg_ptr, format);
+  vfprintf(stderr, format, arg_ptr);
+  va_end(arg_ptr);
+}
+
+//----------------------------------------------------------------
+static void init_mpi(int argc, char **argv)
+{
+#if PIDX_HAVE_MPI
+  if (MPI_Init(&argc, &argv) != MPI_SUCCESS)
+    terminate_with_error_msg("ERROR: MPI_Init error\n");
+  if (MPI_Comm_size(MPI_COMM_WORLD, process_count) != MPI_SUCCESS)
+    terminate_with_error_msg("ERROR: MPI_Comm_size error\n");
+  if (MPI_Comm_rank(MPI_COMM_WORLD, rank) != MPI_SUCCESS)
+    terminate_with_error_msg("ERROR: MPI_Comm_rank error\n");
 #endif
+}
+
+//----------------------------------------------------------------
+static void shutdown_mpi()
+{
+#if PIDX_HAVE_MPI
+  MPI_Finalize();
+#endif
+}
+
+//----------------------------------------------------------------
+// Read all the lines in a file into a list.
+// Return the number of lines read.
+// A line starting with // is treated as a comment and does not increase the count.
+static int read_list_in_file(const char *file_name, char **list)
+{
+  assert(file_name != 0);
+
+  FILE *fp = 0;
+  if (fopen(file_name, "r") == 0)
+    return 0;
+  
+  // first pass, count the number of non-comment lines
+  int line_count = 0;
+  char line[512]; // a line cannot be longer than 512 characters
+  while (fgets(line, sizeof(line), fp) != 0)
+  {
+    if (line[0] != '/' || line[1] != '/')
+      ++line_count;
+  }
+  
+  // second pass, actually read the data
+  list = (char **)calloc(line_count, sizeof(*list));
+  if (list == 0)
+    terminate_with_error_msg("ERROR: Failed to allocate memory for a list of names. Bytes requested = %d (items) * %u (bytes)\n", line_count, sizeof(*list));
+  rewind(fp);
+  int i = 0;
+  while (fgets(line, sizeof(line), fp) != 0)
+  {
+    if (line[0] != '/' || line[1] != '/')
+    {
+      line[strcspn(line, "\r\n")] = 0; // trim the newline character at the end if any
+      list[i] = strdup(line);
+      ++i;
+    }
+  }
+  
+  fclose(fp);
+  return line_count;
+}
+
+//----------------------------------------------------------------
+static void free_memory()
+{
+  free(var_data);
+  var_data = 0;
+  
+  int i = 0;
+  for (i = 0; i < var_count; i++)
+  {
+    free(var_names[i]);
+    var_names[i] = 0;
+  }
+  free(var_names);
+  var_names = 0;
+  free(var_types);
+  free(pidx_vars);
+  
+  for (i = 0; i < time_step_count; i++)
+  {
+    free(hdf5_file_names[i]);
+    hdf5_file_names[i] = 0;
+  }
+  free(hdf5_file_names);
+  hdf5_file_names = 0;
+}
+
+//----------------------------------------------------------------
+///< Parse the input arguments
+static void parse_args(int argc, char **argv)
+{
+  char flags[] = "g:l:f:i:v:";
+  int opt = 0;
+  while ((opt = getopt(argc, argv, flags)) != -1)
+  {
+    switch (opt)
+    {
+      case('g'): // global dimension
+        if ((sscanf(optarg, "%lldx%lldx%lld", &global_box_size[0], &global_box_size[1], &global_box_size[2]) == EOF) ||
+            (global_box_size[0] < 1 || global_box_size[1] < 1 || global_box_size[2] < 1))
+          terminate_with_error_msg("Invalid global dimensions\n%s", usage);
+        break;
+      case('l'): // local dimension
+        if ((sscanf(optarg, "%lldx%lldx%lld", &local_box_size[0], &local_box_size[1], &local_box_size[2]) == EOF) ||
+            (local_box_size[0] < 1 || local_box_size[1] < 1 || local_box_size[2] < 1))
+          terminate_with_error_msg("Invalid local dimension\n%s", usage);
+        break;
+      case('f'): // output file name
+        if (sprintf(output_file_template, "%s", optarg) < 0)
+          terminate_with_error_msg("Invalid output file name template\n%s", usage);
+        sprintf(output_file_name, "%s%s", output_file_template, ".idx");
+        break;
+      case('i'): // a file with a list of hdf5 files
+        if (sprintf(hdf5_file_list, "%s", optarg) < 0)
+          terminate_with_error_msg("Invalid input file\n%s", usage);
+        break;
+      case('v'): // a file with a list of variables
+        if (sprintf(var_file, "%s", optarg) < 0)
+          terminate_with_error_msg("Invalid variable file\n%s", usage);
+        break;
+      default:
+        terminate_with_error_msg("Wrong arguments\n%s", usage);
+    }
+  }
+}
+
+//----------------------------------------------------------------
+static void check_args()
+{
+  if (global_box_size[X] < local_box_size[X] || global_box_size[Y] < local_box_size[Y] || global_box_size[Z] < local_box_size[Z])
+    terminate_with_error_msg("ERROR: Global box is smaller than local box in one of the dimensions\n");
+  
+  // check if the number of processes given by the user is consistent with the actual number of procesess needed
+  int brick_count = (int)((global_box_size[X] + local_box_size[X] - 1) / local_box_size[X]) *
+                    (int)((global_box_size[Y] + local_box_size[Y] - 1) / local_box_size[Y]) *
+                    (int)((global_box_size[Z] + local_box_size[Z] - 1) / local_box_size[Z]);
+  if(brick_count != process_count)
+    terminate_with_error_msg("ERROR: Number of sub-blocks (%d) doesn't match number of processes (%d)\n", brick_count, process_count);
+}
+
+//----------------------------------------------------------------
+static void calculate_per_process_offsets()
+{
+  int sub_div[NUM_DIMS];
+  sub_div[X] = (global_box_size[X] / local_box_size[X]);
+  sub_div[Y] = (global_box_size[Y] / local_box_size[Y]);
+  sub_div[Z] = (global_box_size[Z] / local_box_size[Z]);
+  local_box_offset[Z] = (rank / (sub_div[X] * sub_div[Y])) * local_box_size[Z];
+  int slice = rank % (sub_div[X] * sub_div[Y]);
+  local_box_offset[Y] = (slice / sub_div[X]) * local_box_size[Y];
+  local_box_offset[X] = (slice % sub_div[X]) * local_box_size[X];
+}
+
+//----------------------------------------------------------------
+// Convert an atomic HDF5 datatype to native C datatype
+static enum AtomicType from_hdf5_atomic_type(hid_t atomic_type_id)
+{
+  if (H5Tequal(atomic_type_id, H5T_NATIVE_CHAR))
+    return CHAR;
+  if (H5Tequal(atomic_type_id, H5T_NATIVE_INT))
+    return INT;
+  if (H5Tequal(atomic_type_id, H5T_NATIVE_FLOAT))
+    return FLOAT;
+  if (H5Tequal(atomic_type_id, H5T_NATIVE_DOUBLE))
+    return DOUBLE;
+  return INVALID;
+}
+
+//----------------------------------------------------------------
+// Convert a HDF5 datatype to C native or array datatype
+static struct Type from_hdf5_type(hid_t type_id)
+{
+  struct Type type;
+  H5T_class_t type_class = H5Tget_class(type_id);
+  if (type_class == H5T_ARRAY)
+  {
+    int num_dims = H5Tget_array_ndims(type_id);
+    if (num_dims != 1)
+    {
+      type.atomic_type = INVALID; // we don't support arrays of more than 1 dimension
+      return type;
+    }
+    if (H5Tget_array_dims2(type_id, &type.num_values) < 0)
+    {
+      type.atomic_type = INVALID;
+      return type;
+    }
+  }
+  else if (type_class == H5T_FLOAT || H5T_INTEGER)
+  {
+    type.num_values = 1;
+  }
+  else // we don't support HD5_COMPOUND datatype for example
+  {
+    type.atomic_type = INVALID;
+  }
+  
+  hid_t atomic_type_id = H5Tget_native_type(type_id, H5T_DIR_DESCEND);
+  type.atomic_type = from_hdf5_atomic_type(atomic_type_id);
+  H5Tclose(atomic_type_id);
+  return type;
+}
+
+//----------------------------------------------------------------
+// Open the first HDF5 file and query all the types for all the variables
+static void determine_var_types(hid_t plist_id)
+{
+  assert(hdf5_file_names != 0);
+  assert(var_names != 0);
+  
+  hid_t file_id = H5Fopen(hdf5_file_names[0], H5F_ACC_RDONLY, plist_id);
+  if (file_id < 0)
+    terminate_with_error_msg("ERROR: Cannot open file %s\n", hdf5_file_names[0]);
+  
+  var_types = (struct Type *)calloc(var_count, sizeof(*var_types));
+  
+  int i = 0;
+  for (i = 0; i < var_count; ++i)
+  {
+    hid_t dataset_id = H5Dopen2(file_id, var_names[i], H5P_DEFAULT);
+    if (dataset_id < 0)
+      terminate_with_error_msg("ERROR: Variable %s does not exist in file %s\n", var_names[i], hdf5_file_names[0]);
+    hid_t type_id = H5Dget_type(dataset_id);
+    if (type_id < 0)
+      terminate_with_error_msg("ERROR: Failed to query the type of variable %s\n");
+    var_types[i] = from_hdf5_type(type_id);
+    if (var_types[i].atomic_type == INVALID)
+      terminate_with_error_msg("ERROR: The datatype of the %s variable is not supported\n");
+    H5Tclose(type_id);
+  }
+  
+  H5Fclose(file_id);
+}
+
+//----------------------------------------------------------------
+// Return a negative value when failed, otherwise return 0
+int read_var_from_hdf5(hid_t file_id, const char *var_name, struct Type type)
+{
+  assert(var_name != 0);
+  assert(var_data != 0);
+  
+  hid_t dataset_id = H5Dopen2(file_id, var_name, H5P_DEFAULT);
+  if (dataset_id < 0)
+    terminate_with_error_msg("ERROR: Failed to open HDF5 dataset for variable %s\n", var_name);
+  hid_t mem_dataspace = H5Screate_simple(3, local_box_size, 0);
+  if (mem_dataspace < 0)
+    terminate_with_error_msg("ERROR: Failed to create memory dataspace for variable %s\n", var_name);
+  hid_t file_dataspace = H5Dget_space(dataset_id);
+  if (file_dataspace < 0)
+    terminate_with_error_msg("ERROR: Failed to create file dataspace for variable %s\n", var_name);
+  if (H5Sselect_hyperslab(file_dataspace, H5S_SELECT_SET, local_box_offset, 0, local_box_size, 0) < 0)
+    terminate_with_error_msg("ERROR: Failed to create a hyperslab for variable %s\n", var_name);
+  herr_t read_error = 0;
+  if (type.atomic_type == DOUBLE)
+    read_error = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, mem_dataspace, file_dataspace, H5P_DEFAULT, var_data);
+  else if (type.atomic_type == FLOAT)
+    read_error = H5Dread(dataset_id, H5T_NATIVE_FLOAT, mem_dataspace, file_dataspace, H5P_DEFAULT, var_data);
+  else if (type.atomic_type == INT)
+    read_error = H5Dread(dataset_id, H5T_NATIVE_INT, mem_dataspace, file_dataspace, H5P_DEFAULT, var_data);
+  else if (type.atomic_type == CHAR)
+    read_error = H5Dread(dataset_id, H5T_NATIVE_CHAR, mem_dataspace, file_dataspace, H5P_DEFAULT, var_data);
+  else
+    terminate_with_error_msg("ERROR: Unsupported type. Type = %d\n", type.atomic_type);
+  H5Sclose(mem_dataspace);
+  H5Sclose(file_dataspace);
+  H5Dclose(dataset_id);
+  
+  if (read_error < 0)
+    return -1;
+  return 0;
+}
+
+//----------------------------------------------------------------
+static void to_idx_type_string(struct Type type, char *type_string)
+{
+  assert(type_string != 0);
+  
+  if (type.atomic_type == DOUBLE)
+    sprintf(type_string, "%lld*float64", type.num_values);
+  else if (type.atomic_type == FLOAT)
+      sprintf(type_string, "%lld*float32", type.num_values);
+  else if (type.atomic_type == INT)
+    sprintf(type_string, "%lld*int32", type.num_values);
+  else if (type.atomic_type == CHAR)
+    sprintf(type_string, "%lld*int8", type.num_values);
+  else
+    terminate_with_error_msg("ERROR: Unsupported type. Type = %d\n", type.atomic_type);
+}
+
+//----------------------------------------------------------------
+static void create_pidx_vars(PIDX_file pidx_file)
+{
+  assert(var_names != 0);
+  assert(var_types != 0);
+  
+  pidx_vars = (PIDX_variable *)calloc(var_count, sizeof(*pidx_vars));
+  int i = 0;
+  for (i = 0; i < var_count; ++i)
+  {
+    char type_string[32] = { 0 };
+    to_idx_type_string(var_types[i], type_string);
+    int ret = PIDX_variable_create(var_names[i], var_types[i].atomic_type * 8, type_string, &pidx_vars[i]);
+    if (ret != PIDX_success)
+      terminate_with_error_msg("ERROR: PIDX failed to create variable %s\n", var_names[i]);
+    rank_0_print("Successfully create variable %s, type = %s", var_names[i], type_string);
+  }
+}
+
+//----------------------------------------------------------------
+static void write_var_to_idx(PIDX_file pidx_file, const char *var_name, struct Type type, PIDX_variable pidx_var)
+{
+  assert(var_name != 0);
+  assert(var_data != 0);
+  
+  PIDX_set_point_5D(pidx_local_box_offset, local_box_offset[X], local_box_offset[Y], local_box_offset[Z], 0, 0);
+  PIDX_set_point_5D(pidx_local_box_size, local_box_size[X], local_box_size[Y], local_box_size[Z], 1, 1);
+  int ret = PIDX_success;
+  ret = PIDX_variable_data_layout(pidx_var, pidx_local_box_offset, pidx_local_box_size, var_data, PIDX_ROW_OR_COLUMN_MAJOR);
+  if (ret != PIDX_success)
+    terminate_with_error_msg("ERROR: PIDX failed to specify variable data layout for %s\n", var_name);
+  ret = PIDX_append_and_write_variable(pidx_file, pidx_var);
+  if (ret != PIDX_success)
+    terminate_with_error_msg("ERROR: PIDX failed to append and write variable %s\n", var_name);
+}
+
+//----------------------------------------------------------------
+static void create_pidx_file_and_access(PIDX_file *pidx_file, PIDX_access *pidx_access)
+{
+  int ret = PIDX_create_access(pidx_access);
+  if (ret != PIDX_success)
+    terminate_with_error_msg("ERROR: Failed to create PIDX access\n");
+#if PIDX_HAVE_MPI
+  ret = PIDX_set_mpi_access(*pidx_access, MPI_COMM_WORLD);
+  if (ret != PIDX_success)
+    terminate_with_error_msg("ERROR: Failed to create PIDX MPI access\n");
+#endif
+  ret = PIDX_file_create(output_file_name, PIDX_file_trunc, *pidx_access, pidx_file);
+  if (ret != PIDX_success)
+    terminate_with_error_msg("ERROR: Failed to create PIDX file\n");
+}
+
+//----------------------------------------------------------------
+static void set_pidx_params(PIDX_file pidx_file)
+{
+  int ret = PIDX_set_point_5D(pidx_global_box_size, global_box_size[X], global_box_size[Y], global_box_size[Z], 1, 1);
+  ret = PIDX_set_dims(pidx_file, pidx_global_box_size);
+  if (ret != PIDX_success)
+    terminate_with_error_msg("ERROR: Failed to set PIDX global dimensions\n");
+  ret = PIDX_set_variable_count(pidx_file, var_count);
+  if (ret != 0)
+    terminate_with_error_msg("ERROR: Failed to set PIDX variable count\n");
+  PIDX_time_step_caching_ON();
+}
+
+//----------------------------------------------------------------
+static void shutdown_pidx(PIDX_file pidx_file, PIDX_access pidx_access)
+{
+  PIDX_time_step_caching_OFF();
+  PIDX_close(pidx_file);
+  PIDX_close_access(pidx_access);
+}
+
+//----------------------------------------------------------------
+static hid_t init_hdf5()
+{
+  hid_t plist_id = H5Pcreate(H5P_FILE_ACCESS);
+  if (plist_id < 0)
+    terminate_with_error_msg("ERROR: Failed to create HDF5 file access\n");
+#if PIDX_HAVE_MPI
+  if (H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL) < 0)
+    terminate_with_error_msg("ERROR: Failed to enable MPI for HDF5\n");
+#endif
+  return plist_id;
+}
+
+//----------------------------------------------------------------
+int main(int argc, char **argv)
+{
+  init_mpi(argc, argv);
+  parse_args(argc, argv);
+  check_args();
+  calculate_per_process_offsets();
+  var_count = read_list_in_file(var_file, var_names);
+  rank_0_print("Number of variables = %d\n", var_count);
+  time_step_count = read_list_in_file(hdf5_file_list, hdf5_file_names);
+  rank_0_print("Number of timesteps = %d\n", time_step_count);
+  
+  PIDX_file pidx_file;
+  PIDX_access pidx_access;
+  create_pidx_file_and_access(&pidx_file, &pidx_access);
+  set_pidx_params(pidx_file);
+  
+  hid_t plist_id = init_hdf5();
+  determine_var_types(plist_id);
+  create_pidx_vars(pidx_file);
+  
+  int t = 0;
+  for (t = 0; t < time_step_count; ++t)
+  {
+    rank_0_print("Processing time step %d\n", t);
+    PIDX_set_current_time_step(pidx_file, t);
+    hid_t file_id = H5Fopen(hdf5_file_names[t], H5F_ACC_RDONLY, plist_id);
+    if (file_id < 0)
+      terminate_with_error_msg("ERROR: Failed to open file %s\n", hdf5_file_names[t]);
+    int v = 0;
+    for(v = 0; v < var_count; ++v)
+    {
+      rank_0_print("Processing variable %s\n", var_names[v]);
+      if (read_var_from_hdf5(file_id, var_names[v], var_types[v]) < 0)
+        terminate_with_error_msg("ERROR: Failed to read variable %s from file %s\n", var_names[v], hdf5_file_names[t]);
+      write_var_to_idx(pidx_file, var_names[v], var_types[v], pidx_vars[v]);
+    }
+    H5Fclose(file_id);
+    if (PIDX_flush(pidx_file) != PIDX_success)
+      terminate_with_error_msg("ERROR: Failed to flush variable %s, time step %d\n", var_names[v], t);
+  }
+  
+  shutdown_pidx(pidx_file, pidx_access);
+  H5Pclose(plist_id);
+  
+  free_memory();
+  shutdown_mpi();
+}


### PR DESCRIPTION
- This utility can now query the types of variables directly from HDF5 files.
- Read one field at a time instead of all fields into memory at once.
- Improve error reporting to users.
- The code is also refactored to make it easier to follow.