### PR TITLE
Add first and last time getter

### DIFF
--- a/pidx/PIDX.c
+++ b/pidx/PIDX.c
@@ -661,6 +661,22 @@ PIDX_return_code PIDX_file_open(const char* filename, PIDX_flags flags, PIDX_acc
       {
         if( fgets(line, sizeof line, fp) == NULL)
           return PIDX_err_file;
+        
+        line[strcspn(line, "\r\n")] = 0;
+        
+        pch = strtok(line, " ");
+        
+        if(pch != NULL)
+          (*file)->idx->first_tstep = atoi(pch);
+        else
+          return PIDX_err_file;
+        
+        pch = strtok(NULL, " ");
+        
+        if(pch != NULL)
+          (*file)->idx->last_tstep = atoi(pch);
+        else
+          return PIDX_err_file;
       }
     }
     fclose(fp);
@@ -999,7 +1015,25 @@ PIDX_return_code PIDX_get_variable_count(PIDX_file file, int* variable_count)
   return PIDX_success;
 }
 
+PIDX_return_code PIDX_get_first_tstep(PIDX_file file, int* tstep)
+{
+  if(!file)
+    return PIDX_err_file;
+  
+  *tstep = file->idx->first_tstep;
+  
+  return PIDX_success;
+}
 
+PIDX_return_code PIDX_get_last_tstep(PIDX_file file, int* tstep)
+{
+  if(!file)
+    return PIDX_err_file;
+  
+  *tstep = file->idx->last_tstep;
+  
+  return PIDX_success;
+}
 
 PIDX_return_code PIDX_set_compression_type(PIDX_file file, int compression_type)
 {

--- a/pidx/PIDX.h
+++ b/pidx/PIDX.h
@@ -297,7 +297,15 @@ PIDX_return_code PIDX_set_variable_count(PIDX_file file, int  variable_count);
 /// \return The number of variables.
 PIDX_return_code PIDX_get_variable_count(PIDX_file file, int* variable_count);
 
+/// Gets the index of the first timestep in the IDX file.
+/// \param file The IDX file handler.
+/// \return The first timestep index.
+PIDX_return_code PIDX_get_first_tstep(PIDX_file file, int* tstep);
 
+/// Gets the index of the last timestep in the IDX file.
+/// \param file The IDX file handler.
+/// \return The last timestep index.
+PIDX_return_code PIDX_get_last_tstep(PIDX_file file, int* tstep);
 
 /// Sets the index of the variable at which location it needs to be written at or read from in an IDX file.
 /// \param file The IDX file handler.

--- a/pidx/data_handle/PIDX_idx_data_structs.h
+++ b/pidx/data_handle/PIDX_idx_data_structs.h
@@ -132,9 +132,14 @@ struct idx_file_struct
   int variable_index_tracker;
   PIDX_variable variable[1024];
   
+
   char filename_global[1024];
   char filename_partition[1024];
   char filename_file_zero[1024];
+
+  int first_tstep;                                                     ///< The first timestep index in the IDX file
+  int last_tstep;                                                      ///< The last timestep index in the IDX file
+
   char filename[1024];
 
   int bits_per_block;

--- a/pidx/io/PIDX_raw_io/PIDX_raw_io.c
+++ b/pidx/io/PIDX_raw_io/PIDX_raw_io.c
@@ -396,10 +396,12 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
     return PIDX_err_io;
   }
 
+#if INVERT_ENDIANESS 
   uint32_t temp_max_patch_count = 0;
   int32_Reverse_Endian(max_patch_count, &temp_max_patch_count);
   max_patch_count = temp_max_patch_count;
-
+#endif
+  
   uint32_t *size_buffer = malloc((number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)) * sizeof(uint32_t));
   memset(size_buffer, 0, (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)) * sizeof(uint32_t));
 
@@ -414,7 +416,7 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
 
 #if INVERT_ENDIANESS
   int buff_i;
-  for(buff_i = 0; buff_i<  (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)); buff_i++){
+  for(buff_i = 0; buff_i < (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)); buff_i++){
     uint32_t temp_value;
     int32_Reverse_Endian(size_buffer[buff_i], &temp_value);
     size_buffer[buff_i] = temp_value;

--- a/pidx/io/PIDX_raw_io/PIDX_raw_io.c
+++ b/pidx/io/PIDX_raw_io/PIDX_raw_io.c
@@ -1,5 +1,7 @@
 #include "../PIDX_io.h"
 
+#define INVERT_ENDIANESS 1
+
 static int maximum_neighbor_count = 256;
 
 static int intersectNDChunk(Ndim_patch A, Ndim_patch B);
@@ -324,6 +326,23 @@ PIDX_return_code PIDX_raw_write(PIDX_raw_io file, int start_var_index, int end_v
     return !(check_bit);
   }
 
+#if INVERT_ENDIANESS 
+
+inline int
+int32_Reverse_Endian(int val, unsigned char *outbuf)
+{
+    unsigned char *data = ((unsigned char *)&val) + 3;
+    unsigned char *out = outbuf;
+    
+    *out++ = *data--;
+    *out++ = *data--;
+    *out++ = *data--;
+    *out = *data;
+    
+    return 4;
+}
+
+#endif
 
 PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int end_var_index)
 {
@@ -354,6 +373,7 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
   free(idx_directory_path);
 
   uint32_t number_cores = 0;
+  printf("opening %s\n", size_path);
   int fp = open(size_path, O_RDONLY);
   ssize_t write_count = pread(fp, &number_cores, sizeof(uint32_t), 0);
   if (write_count != sizeof(uint32_t))
@@ -362,6 +382,12 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
     return PIDX_err_io;
   }
 
+#if INVERT_ENDIANESS 
+  uint32_t temp_number_cores = 0;
+  int32_Reverse_Endian(number_cores, &temp_number_cores);
+  number_cores = temp_number_cores;
+#endif
+
   uint32_t max_patch_count = 0;
   write_count = pread(fp, &max_patch_count, sizeof(uint32_t), sizeof(uint32_t));
   if (write_count != sizeof(uint32_t))
@@ -369,6 +395,10 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
     fprintf(stderr, "[%s] [%d] pread() failed.\n", __FILE__, __LINE__);
     return PIDX_err_io;
   }
+
+  uint32_t temp_max_patch_count = 0;
+  int32_Reverse_Endian(max_patch_count, &temp_max_patch_count);
+  max_patch_count = temp_max_patch_count;
 
   uint32_t *size_buffer = malloc((number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)) * sizeof(uint32_t));
   memset(size_buffer, 0, (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)) * sizeof(uint32_t));
@@ -382,6 +412,14 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
 
   close(fp);
 
+#if INVERT_ENDIANESS
+  int buff_i;
+  for(buff_i = 0; buff_i<  (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)); buff_i++){
+    uint32_t temp_value;
+    int32_Reverse_Endian(size_buffer[buff_i], &temp_value);
+    size_buffer[buff_i] = temp_value;
+  }
+#endif
 
   uint32_t *offset_buffer = malloc((number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)) * sizeof(uint32_t));
   memset(offset_buffer, 0, (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)) * sizeof(uint32_t));
@@ -395,6 +433,13 @@ PIDX_return_code PIDX_forced_raw_read(PIDX_raw_io file, int start_var_index, int
   }
   close(fp1);
 
+#if INVERT_ENDIANESS
+  for(buff_i = 0; buff_i<  (number_cores * (max_patch_count * PIDX_MAX_DIMENSIONS + 1)); buff_i++){
+    uint32_t temp_value;
+    int32_Reverse_Endian(offset_buffer[buff_i], &temp_value);
+    offset_buffer[buff_i] = temp_value;
+  }
+#endif
 
   PIDX_time time = file->idx_d->time;
   time->populate_idx_start_time = PIDX_get_time();


### PR DESCRIPTION
Getters for first and last timestep (from .idx)
This is fundamental for the VisIt reader. 

I added a TEMPORARY fix for the endianness in the metadata files (RAW format), that just uses a define INVERT_ENDIANESS.

The best way would be to write a “magic" number at the beginning of the binary file (let’s say 7) and then when we read we first check this integer. If it is your magic number is ok, otherwise you have to invert the endianness.

Otherwise a PIDX_set_endianess and PIDX_get_endianess would not be bad...