### PR TITLE
fix conflicting zfp types

### DIFF
--- a/external/zfp/inc/bitstream.h
+++ b/external/zfp/inc/bitstream.h
@@ -42,10 +42,10 @@ uint stream_read_bit(bitstream* stream);
 uint stream_write_bit(bitstream* stream, uint bit);
 
 /* read 0 <= n <= 64 bits */
-uint64 stream_read_bits(bitstream* stream, uint n);
+zfp_uint64 stream_read_bits(bitstream* stream, uint n);
 
 /* write 0 <= n <= 64 low bits of value and return remaining bits */
-uint64 stream_write_bits(bitstream* stream, uint64 value, uint n);
+zfp_uint64 stream_write_bits(bitstream* stream, zfp_uint64 value, uint n);
 
 /* return bit offset to next bit to be read */
 size_t stream_rtell(const bitstream* stream);

--- a/external/zfp/inc/types.h
+++ b/external/zfp/inc/types.h
@@ -7,24 +7,24 @@ typedef unsigned int uint;
 
 #if __STDC_VERSION__ >= 199901L
   #include <stdint.h>
-  typedef int8_t int8;
-  typedef uint8_t uint8;
-  typedef int16_t int16;
-  typedef uint16_t uint16;
-  typedef int32_t int32;
-  typedef uint32_t uint32;
-  typedef uint64_t int64;
-  typedef uint64_t uint64;
+  typedef int8_t zfp_int8;
+  typedef uint8_t zfp_uint8;
+  typedef int16_t zfp_int16;
+  typedef uint16_t zfp_uint16;
+  typedef int32_t zfp_int32;
+  typedef uint32_t zfp_uint32;
+  typedef uint64_t zfp_int64;
+  typedef uint64_t zfp_uint64;
 #else
   /* assume common integer types in C89 */
-  typedef signed char int8;
-  typedef unsigned char uint8;
-  typedef signed short int16;
-  typedef unsigned short uint16;
-  typedef signed int int32;
-  typedef unsigned int uint32;
-  typedef signed long long int64; /* not ANSI C89 compliant */
-  typedef unsigned long long uint64; /* not ANSI C89 compliant */
+  typedef signed char zfp_int8;
+  typedef unsigned char zfp_uint8;
+  typedef signed short zfp_int16;
+  typedef unsigned short zfp_uint16;
+  typedef signed int zfp_int32;
+  typedef unsigned int zfp_uint32;
+  typedef signed long long zfp_int64; /* not ANSI C89 compliant */
+  typedef unsigned long long zfp_uint64; /* not ANSI C89 compliant */
 #endif
 
 #endif

--- a/external/zfp/inc/zfp.h
+++ b/external/zfp/inc/zfp.h
@@ -148,7 +148,7 @@ zfp_stream_bit_stream(
 );
 
 /* get all compression parameters in a compact representation */
-uint64                     /* 12- or 64-bit encoding of parameters */
+zfp_uint64                     /* 12- or 64-bit encoding of parameters */
 zfp_stream_mode(
   const zfp_stream* zfp    /* compressed stream */
 );
@@ -215,7 +215,7 @@ zfp_stream_set_accuracy(
 int                   /* nonzero upon success */
 zfp_stream_set_mode(
   zfp_stream* stream, /* compressed stream */
-  uint64 mode         /* 12- or 64-bit encoding of parameters */
+  zfp_uint64 mode         /* 12- or 64-bit encoding of parameters */
 );
 
 /* set all compression parameters (expert mode) */
@@ -308,7 +308,7 @@ zfp_field_stride(
 );
 
 /* field scalar type and dimensions */
-uint64                   /* compact 52-bit encoding of metadata */
+zfp_uint64                   /* compact 52-bit encoding of metadata */
 zfp_field_metadata(
   const zfp_field* field /* field metadata */
 );
@@ -381,7 +381,7 @@ zfp_field_set_stride_3d(
 int                 /* nonzero upon success */
 zfp_field_set_metadata(
   zfp_field* field, /* field metadata */
-  uint64 meta       /* compact 52-bit encoding of metadata */
+  zfp_uint64 meta       /* compact 52-bit encoding of metadata */
 );
 
 /* high-level API: compression and decompression --------------------------- */
@@ -420,7 +420,7 @@ int                   /* nonzero upon success */
 zfp_decompress2_double(
   zfp_stream* stream, /* compressed stream */
   zfp_field* field,    /* field metadata */
-  int64* data,
+  zfp_int64* data,
   int* emax
 );
 
@@ -473,8 +473,8 @@ needed for the compressed block.
 */
 
 /* encode 1D contiguous block of 4 values */
-uint zfp_encode_block_int32_1(zfp_stream* stream, const int32* block);
-uint zfp_encode_block_int64_1(zfp_stream* stream, const int64* block);
+uint zfp_encode_block_int32_1(zfp_stream* stream, const zfp_int32* block);
+uint zfp_encode_block_int64_1(zfp_stream* stream, const zfp_int64* block);
 uint zfp_encode_block_float_1(zfp_stream* stream, const float* block);
 uint zfp_encode_block_double_1(zfp_stream* stream, const double* block);
 
@@ -485,8 +485,8 @@ uint zfp_encode_partial_block_strided_float_1(zfp_stream* stream, const float* p
 uint zfp_encode_partial_block_strided_double_1(zfp_stream* stream, const double* p, uint nx, int sx);
 
 /* encode 2D contiguous block of 4x4 values */
-uint zfp_encode_block_int32_2(zfp_stream* stream, const int32* block);
-uint zfp_encode_block_int64_2(zfp_stream* stream, const int64* block);
+uint zfp_encode_block_int32_2(zfp_stream* stream, const zfp_int32* block);
+uint zfp_encode_block_int64_2(zfp_stream* stream, const zfp_int64* block);
 uint zfp_encode_block_float_2(zfp_stream* stream, const float* block);
 uint zfp_encode_block_double_2(zfp_stream* stream, const double* block);
 
@@ -497,8 +497,8 @@ uint zfp_encode_block_strided_float_2(zfp_stream* stream, const float* p, int sx
 uint zfp_encode_block_strided_double_2(zfp_stream* stream, const double* p, int sx, int sy);
 
 /* encode 3D contiguous block of 4x4x4 values */
-uint zfp_encode_block_int32_3(zfp_stream* stream, const int32* block);
-uint zfp_encode_block_int64_3(zfp_stream* stream, const int64* block);
+uint zfp_encode_block_int32_3(zfp_stream* stream, const zfp_int32* block);
+uint zfp_encode_block_int64_3(zfp_stream* stream, const zfp_int64* block);
 uint zfp_encode_block_float_3(zfp_stream* stream, const float* block);
 uint zfp_encode_block2_float_3(zfp_stream* stream, const float* block);
 uint zfp_encode_block_double_3(zfp_stream* stream, const double* block);
@@ -523,8 +523,8 @@ further details.
 */
 
 /* decode 1D contiguous block of 4 values */
-uint zfp_decode_block_int32_1(zfp_stream* stream, int32* block);
-uint zfp_decode_block_int64_1(zfp_stream* stream, int64* block);
+uint zfp_decode_block_int32_1(zfp_stream* stream, zfp_int32* block);
+uint zfp_decode_block_int64_1(zfp_stream* stream, zfp_int64* block);
 uint zfp_decode_block_float_1(zfp_stream* stream, float* block);
 uint zfp_decode_block_double_1(zfp_stream* stream, double* block);
 
@@ -535,8 +535,8 @@ uint zfp_decode_partial_block_strided_float_1(zfp_stream* stream, float* p, uint
 uint zfp_decode_partial_block_strided_double_1(zfp_stream* stream, double* p, uint nx, int sx);
 
 /* decode 2D contiguous block of 4x4 values */
-uint zfp_decode_block_int32_2(zfp_stream* stream, int32* block);
-uint zfp_decode_block_int64_2(zfp_stream* stream, int64* block);
+uint zfp_decode_block_int32_2(zfp_stream* stream, zfp_int32* block);
+uint zfp_decode_block_int64_2(zfp_stream* stream, zfp_int64* block);
 uint zfp_decode_block_float_2(zfp_stream* stream, float* block);
 uint zfp_decode_block_double_2(zfp_stream* stream, double* block);
 
@@ -547,36 +547,36 @@ uint zfp_decode_partial_block_strided_float_2(zfp_stream* stream, float* p, uint
 uint zfp_decode_partial_block_strided_double_2(zfp_stream* stream, double* p, uint nx, uint ny, int sx, int sy);
 
 /* decode 3D contiguous block of 4x4x4 values */
-uint zfp_decode_block_int32_3(zfp_stream* stream, int32* block);
-uint zfp_decode_block_int64_3(zfp_stream* stream, int64* block);
+uint zfp_decode_block_int32_3(zfp_stream* stream, zfp_int32* block);
+uint zfp_decode_block_int64_3(zfp_stream* stream, zfp_int64* block);
 uint zfp_decode_block_float_3(zfp_stream* stream, float* block);
 uint zfp_decode_block2_float_3(zfp_stream* stream, int* block, int* emax);
 uint zfp_decode_block_double_3(zfp_stream* stream, double* block);
-uint zfp_decode_block2_double_3(zfp_stream* stream, int64* block, int* emax);
+uint zfp_decode_block2_double_3(zfp_stream* stream, zfp_int64* block, int* emax);
 
 /* decode 3D complete or partial block from strided array */
 uint zfp_decode_block_strided_float_3(zfp_stream* stream, float* p, int sx, int sy, int sz);
 uint zfp_decode_block_strided2_float_3(zfp_stream* stream, int* p, int sx, int sy, int sz, int* emax);
 uint zfp_decode_block_strided_double_3(zfp_stream* stream, double* p, int sx, int sy, int sz);
-uint zfp_decode_block_strided2_double_3(zfp_stream* stream, int64* p, int sx, int sy, int sz, int* emax);
+uint zfp_decode_block_strided2_double_3(zfp_stream* stream, zfp_int64* p, int sx, int sy, int sz, int* emax);
 uint zfp_decode_partial_block_strided_float_3(zfp_stream* stream, float* p, uint nx, uint ny, uint nz, int sx, int sy, int sz);
 uint zfp_decode_partial_block_strided2_float_3(zfp_stream* stream, int* p, uint nx, uint ny, uint nz, int sx, int sy, int sz, int* emax);
 uint zfp_decode_partial_block_strided_double_3(zfp_stream* stream, double* p, uint nx, uint ny, uint nz, int sx, int sy, int sz);
-uint zfp_decode_partial_block_strided2_double_3(zfp_stream* stream, int64* p, uint nx, uint ny, uint nz, int sx, int sy, int sz, int* emax);
+uint zfp_decode_partial_block_strided2_double_3(zfp_stream* stream, zfp_int64* p, uint nx, uint ny, uint nz, int sx, int sy, int sz, int* emax);
 
 /* low-level API: utility functions ---------------------------------------- */
 
 /* convert dims-dimensional contiguous block to 32-bit integer type */
-void zfp_promote_int8_to_int32(int32* oblock, const int8* iblock, uint dims);
-void zfp_promote_uint8_to_int32(int32* oblock, const uint8* iblock, uint dims);
-void zfp_promote_int16_to_int32(int32* oblock, const int16* iblock, uint dims);
-void zfp_promote_uint16_to_int32(int32* oblock, const uint16* iblock, uint dims);
+void zfp_promote_int8_to_int32(zfp_int32* oblock, const zfp_int8* iblock, uint dims);
+void zfp_promote_uint8_to_int32(zfp_int32* oblock, const zfp_uint8* iblock, uint dims);
+void zfp_promote_int16_to_int32(zfp_int32* oblock, const zfp_int16* iblock, uint dims);
+void zfp_promote_uint16_to_int32(zfp_int32* oblock, const zfp_uint16* iblock, uint dims);
 
 /* convert dims-dimensional contiguous block from 32-bit integer type */
-void zfp_demote_int32_to_int8(int8* oblock, const int32* iblock, uint dims);
-void zfp_demote_int32_to_uint8(uint8* oblock, const int32* iblock, uint dims);
-void zfp_demote_int32_to_int16(int16* oblock, const int32* iblock, uint dims);
-void zfp_demote_int32_to_uint16(uint16* oblock, const int32* iblock, uint dims);
+void zfp_demote_int32_to_int8(zfp_int8* oblock, const zfp_int32* iblock, uint dims);
+void zfp_demote_int32_to_uint8(zfp_uint8* oblock, const zfp_int32* iblock, uint dims);
+void zfp_demote_int32_to_int16(zfp_int16* oblock, const zfp_int32* iblock, uint dims);
+void zfp_demote_int32_to_uint16(zfp_uint16* oblock, const zfp_int32* iblock, uint dims);
 
 #ifdef __cplusplus
 }

--- a/external/zfp/src/inline/bitstream.c
+++ b/external/zfp/src/inline/bitstream.c
@@ -113,7 +113,7 @@ The following assumptions and restrictions apply:
   typedef BIT_STREAM_WORD_TYPE word;
 #else
   /* use maximum word size by default for highest speed */
-  typedef uint64 word;
+  typedef zfp_uint64 word;
 #endif
 
 /* number of bits in a buffered word */
@@ -220,16 +220,16 @@ stream_write_bit(bitstream* s, uint bit)
 }
 
 /* read 0 <= n <= 64 bits */
-_inline uint64
+_inline zfp_uint64
 stream_read_bits(bitstream* s, uint n)
 {
-  uint64 value = s->buffer;
+  zfp_uint64 value = s->buffer;
   if (s->bits < n) {
     /* keep fetching wsize bits until enough bits are buffered */
     do {
       /* assert: 0 <= s->bits < n <= 64 */
       s->buffer = stream_read_word(s);
-      value += (uint64)s->buffer << s->bits;
+      value += (zfp_uint64)s->buffer << s->bits;
       s->bits += wsize;
     } while (sizeof(s->buffer) < sizeof(value) && s->bits < n);
     /* assert: 1 <= n <= s->bits < n + wsize */
@@ -242,21 +242,21 @@ stream_read_bits(bitstream* s, uint n)
       /* assert: 1 <= s->bits < wsize */
       s->buffer >>= wsize - s->bits;
       /* assert: 1 <= n <= 64 */
-      value &= ((uint64)2 << (n - 1)) - 1;
+      value &= ((zfp_uint64)2 << (n - 1)) - 1;
     }
   }
   else {
     /* assert: 0 <= n <= s->bits < wsize <= 64 */
     s->bits -= n;
     s->buffer >>= n;
-    value &= ((uint64)1 << n) - 1;
+    value &= ((zfp_uint64)1 << n) - 1;
   }
   return value;
 }
 
 /* write 0 <= n <= 64 low bits of value and return remaining bits */
-_inline uint64
-stream_write_bits(bitstream* s, uint64 value, uint n)
+_inline zfp_uint64
+stream_write_bits(bitstream* s, zfp_uint64 value, uint n)
 {
   /* append bit string to buffer */
   s->buffer += value << s->bits;

--- a/external/zfp/src/template/decode.c
+++ b/external/zfp/src/template/decode.c
@@ -79,7 +79,7 @@ _t1(decode_ints, UInt)(bitstream* _restrict stream, uint maxbits, uint maxprec, 
   uint kmin = intprec > maxprec ? intprec - maxprec : 0;
   uint bits = maxbits;
   uint i, k, m, n;
-  uint64 x;
+  zfp_uint64 x;
 
   /* initialize data array to all zeros */
   for (i = 0; i < size; i++)
@@ -92,7 +92,7 @@ _t1(decode_ints, UInt)(bitstream* _restrict stream, uint maxbits, uint maxprec, 
     bits -= m;
     x = stream_read_bits(&s, m);
     /* unary run-length decode remainder of bit plane */
-    for (; n < size && bits && (bits--, stream_read_bit(&s)); x += (uint64)1 << n++)
+    for (; n < size && bits && (bits--, stream_read_bit(&s)); x += (zfp_uint64)1 << n++)
       for (; n < size - 1 && bits && (bits--, !stream_read_bit(&s)); n++)
         ;
     /* deposit bit plane from x */
@@ -114,7 +114,7 @@ _t1(decode_ints2, UInt)(bitstream* _restrict stream, uint maxbits, uint maxprec,
   uint kmin = intprec > maxprec ? intprec - maxprec : 0;
   uint bits = maxbits;
   uint i, k, m, n;
-  uint64 x;
+  zfp_uint64 x;
 
   /* initialize data array to all zeros */
   for (i = 0; i < size; i++)
@@ -127,7 +127,7 @@ _t1(decode_ints2, UInt)(bitstream* _restrict stream, uint maxbits, uint maxprec,
     bits -= m;
     x = stream_read_bits(&s, m);
     /* unary run-length decode remainder of bit plane */
-    for (; n < size && bits && (bits--, stream_read_bit(&s)); x += (uint64)1 << n++)
+    for (; n < size && bits && (bits--, stream_read_bit(&s)); x += (zfp_uint64)1 << n++)
       for (; n < size - 1 && bits && (bits--, !stream_read_bit(&s)); n++)
         ;
     /* deposit bit plane from x */    

--- a/external/zfp/src/template/encode.c
+++ b/external/zfp/src/template/encode.c
@@ -128,14 +128,14 @@ _t1(encode_ints, UInt)(bitstream* _restrict stream, uint maxbits, uint maxprec, 
   uint kmin = intprec > maxprec ? intprec - maxprec : 0;
   uint bits = maxbits;
   uint i, k, m, n;
-  uint64 x;
+  zfp_uint64 x;
 
   /* encode one bit plane at a time from MSB to LSB */
   for (k = intprec, n = 0; bits && k-- > kmin;) {
     /* step 1: extract bit plane #k to x */
     x = 0;
     for (i = 0; i < size; i++)
-      x += (uint64)((data[i] >> k) & 1u) << i;
+      x += (zfp_uint64)((data[i] >> k) & 1u) << i;
     /* step 2: encode first n bits of bit plane */
     m = MIN(n, bits);
     bits -= m;
@@ -160,14 +160,14 @@ _t1(encode_ints2, UInt)(bitstream* _restrict stream, uint maxbits, uint maxprec,
   uint kmin = intprec > maxprec ? intprec - maxprec : 0;
   uint bits = maxbits;
   uint i, k, m, n;
-  uint64 x;
+  zfp_uint64 x;
 
   /* encode one bit plane at a time from MSB to LSB */
   for (k = intprec, n = 0; bits && k-- > kmin;) {
     /* step 1: extract bit plane #k to x */
     x = 0;
     for (i = 1; i < size; i++)
-      x += (uint64)((data[i] >> k) & 1u) << (i-1);
+      x += (zfp_uint64)((data[i] >> k) & 1u) << (i-1);
     /* step 2: encode first n bits of bit plane */
     m = MIN(n, bits);
     bits -= m;

--- a/external/zfp/src/traitsd.h
+++ b/external/zfp/src/traitsd.h
@@ -1,8 +1,8 @@
 /* double-precision floating-point traits */
 
 #define Scalar double                /* floating-point type */
-#define Int int64                    /* corresponding signed integer type */
-#define UInt uint64                  /* corresponding unsigned integer type */
+#define Int zfp_int64                    /* corresponding signed integer type */
+#define UInt zfp_uint64                  /* corresponding unsigned integer type */
 #define EBITS 11                     /* number of exponent bits */
 #define NBMASK 0xaaaaaaaaaaaaaaaaull /* negabinary mask */
 

--- a/external/zfp/src/traitsf.h
+++ b/external/zfp/src/traitsf.h
@@ -1,8 +1,8 @@
 /* single-precision floating-point traits */
 
 #define Scalar float       /* floating-point type */
-#define Int int32          /* corresponding signed integer type */
-#define UInt uint32        /* corresponding unsigned integer type */
+#define Int zfp_int32          /* corresponding signed integer type */
+#define UInt zfp_uint32        /* corresponding unsigned integer type */
 #define EBITS 8            /* number of exponent bits */
 #define NBMASK 0xaaaaaaaau /* negabinary mask */
 

--- a/external/zfp/src/zfp.c
+++ b/external/zfp/src/zfp.c
@@ -14,7 +14,7 @@
 #undef Int
 
 #define Scalar double
-#define Int int64
+#define Int zfp_int64
 #include "template/compress.c"
 #include "template/decompress.c"
 #undef Scalar
@@ -27,9 +27,9 @@ type_precision(zfp_type type)
 {
   switch (type) {
     case zfp_type_int32:
-      return CHAR_BIT * (uint)sizeof(int32);
+      return CHAR_BIT * (uint)sizeof(zfp_int32);
     case zfp_type_int64:
-      return CHAR_BIT * (uint)sizeof(int64);
+      return CHAR_BIT * (uint)sizeof(zfp_int64);
     case zfp_type_float:
       return CHAR_BIT * (uint)sizeof(float);
     case zfp_type_double:
@@ -159,10 +159,10 @@ zfp_field_stride(const zfp_field* field, int* stride)
   return field->sx || field->sy || field->sz;
 }
 
-uint64
+zfp_uint64
 zfp_field_metadata(const zfp_field* field)
 {
-  uint64 meta = 0;
+  zfp_uint64 meta = 0;
   /* 48 bits for dimensions */
   switch (zfp_field_dimensionality(field)) {
     case 1:
@@ -255,7 +255,7 @@ zfp_field_set_stride_3d(zfp_field* field, int sx, int sy, int sz)
 }
 
 int
-zfp_field_set_metadata(zfp_field* field, uint64 meta)
+zfp_field_set_metadata(zfp_field* field, zfp_uint64 meta)
 {
   uint dims;
   field->type = (zfp_type)((meta & 0x3u) + 1); meta >>= 2;
@@ -306,10 +306,10 @@ zfp_stream_bit_stream(const zfp_stream* zfp)
   return zfp->stream;
 }
 
-uint64
+zfp_uint64
 zfp_stream_mode(const zfp_stream* zfp)
 {
-  uint64 mode = 0;
+  zfp_uint64 mode = 0;
   uint minbits;
   uint maxbits;
   uint maxprec;
@@ -462,7 +462,7 @@ zfp_stream_set_accuracy(zfp_stream* zfp, double tolerance, zfp_type type)
 }
 
 int
-zfp_stream_set_mode(zfp_stream* zfp, uint64 mode)
+zfp_stream_set_mode(zfp_stream* zfp, zfp_uint64 mode)
 {
   if (mode <= ZFP_MODE_SHORT_MAX) {
     /* 12-bit encoding of one of three modes */
@@ -531,73 +531,73 @@ zfp_stream_rewind(zfp_stream* zfp)
 /* public functions: utility functions --------------------------------------*/
 
 void
-zfp_promote_int8_to_int32(int32* oblock, const int8* iblock, uint dims)
+zfp_promote_int8_to_int32(zfp_int32* oblock, const zfp_int8* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--)
-    *oblock++ = (int32)*iblock++ << 23;
+    *oblock++ = (zfp_int32)*iblock++ << 23;
 }
 
 void
-zfp_promote_uint8_to_int32(int32* oblock, const uint8* iblock, uint dims)
+zfp_promote_uint8_to_int32(zfp_int32* oblock, const zfp_uint8* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--)
-    *oblock++ = ((int32)*iblock++ - 0x80) << 23;
+    *oblock++ = ((zfp_int32)*iblock++ - 0x80) << 23;
 }
 
 void
-zfp_promote_int16_to_int32(int32* oblock, const int16* iblock, uint dims)
+zfp_promote_int16_to_int32(zfp_int32* oblock, const zfp_int16* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--)
-    *oblock++ = (int32)*iblock++ << 15;
+    *oblock++ = (zfp_int32)*iblock++ << 15;
 }
 
 void
-zfp_promote_uint16_to_int32(int32* oblock, const uint16* iblock, uint dims)
+zfp_promote_uint16_to_int32(zfp_int32* oblock, const zfp_uint16* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--)
-    *oblock++ = ((int32)*iblock++ - 0x8000) << 15;
+    *oblock++ = ((zfp_int32)*iblock++ - 0x8000) << 15;
 }
 
 void
-zfp_demote_int32_to_int8(int8* oblock, const int32* iblock, uint dims)
+zfp_demote_int32_to_int8(zfp_int8* oblock, const zfp_int32* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--) {
-    int32 i = *iblock++ >> 23;
+    zfp_int32 i = *iblock++ >> 23;
     *oblock++ = MAX(-0x80, MIN(i, 0x7f));
   }
 }
 
 void
-zfp_demote_int32_to_uint8(uint8* oblock, const int32* iblock, uint dims)
+zfp_demote_int32_to_uint8(zfp_uint8* oblock, const zfp_int32* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--) {
-    int32 i = (*iblock++ >> 23) + 0x80;
+    zfp_int32 i = (*iblock++ >> 23) + 0x80;
     *oblock++ = MAX(0x00, MIN(i, 0xff));
   }
 }
 
 void
-zfp_demote_int32_to_int16(int16* oblock, const int32* iblock, uint dims)
+zfp_demote_int32_to_int16(zfp_int16* oblock, const zfp_int32* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--) {
-    int32 i = *iblock++ >> 15;
+    zfp_int32 i = *iblock++ >> 15;
     *oblock++ = MAX(-0x8000, MIN(i, 0x7fff));
   }
 }
 
 void
-zfp_demote_int32_to_uint16(uint16* oblock, const int32* iblock, uint dims)
+zfp_demote_int32_to_uint16(zfp_uint16* oblock, const zfp_int32* iblock, uint dims)
 {
   uint count = 1u << (2 * dims);
   while (count--) {
-    int32 i = (*iblock++ >> 15) + 0x8000;
+    zfp_int32 i = (*iblock++ >> 15) + 0x8000;
     *oblock++ = MAX(0x0000, MIN(i, 0xffff));
   }
 }
@@ -712,7 +712,7 @@ zfp_decompress2_float(zfp_stream* zfp, zfp_field* field, int* data, int* emax)
 }
 
 int
-zfp_decompress2_double(zfp_stream* zfp, zfp_field* field, int64* data, int* emax)
+zfp_decompress2_double(zfp_stream* zfp, zfp_field* field, zfp_int64* data, int* emax)
 {
   uint dims = zfp_field_dimensionality(field);
   uint type = field->type;
@@ -745,13 +745,13 @@ zfp_write_header(zfp_stream* zfp, const zfp_field* field, uint mask)
   }
   /* 52-bit field metadata */
   if (mask & ZFP_HEADER_FIELD) {
-    uint64 meta = zfp_field_metadata(field);
+    zfp_uint64 meta = zfp_field_metadata(field);
     stream_write_bits(zfp->stream, meta, ZFP_META_BITS);
     bits += ZFP_META_BITS;
   }
   /* 12- or 64-bit compression parameters */
   if (mask & ZFP_HEADER_PARAMS) {
-    uint64 mode = zfp_stream_mode(zfp);
+    zfp_uint64 mode = zfp_stream_mode(zfp);
     uint size = mode > ZFP_MODE_SHORT_MAX ? ZFP_MODE_LONG_BITS : ZFP_MODE_SHORT_BITS;
     stream_write_bits(zfp->stream, mode, size);
     bits += size;
@@ -772,13 +772,13 @@ zfp_read_header(zfp_stream* zfp, zfp_field* field, uint mask)
     bits += ZFP_MAGIC_BITS;
   }
   if (mask & ZFP_HEADER_FIELD) {
-    uint64 meta = stream_read_bits(zfp->stream, ZFP_META_BITS);
+    zfp_uint64 meta = stream_read_bits(zfp->stream, ZFP_META_BITS);
     if (!zfp_field_set_metadata(field, meta))
       return 0;
     bits += ZFP_META_BITS;
   }
   if (mask & ZFP_HEADER_PARAMS) {
-    uint64 mode = stream_read_bits(zfp->stream, ZFP_MODE_SHORT_BITS);
+    zfp_uint64 mode = stream_read_bits(zfp->stream, ZFP_MODE_SHORT_BITS);
     bits += ZFP_MODE_SHORT_BITS;
     if (mode > ZFP_MODE_SHORT_MAX) {
       uint size = ZFP_MODE_LONG_BITS - ZFP_MODE_SHORT_BITS;

--- a/pidx/io/idx/partition.c
+++ b/pidx/io/idx/partition.c
@@ -579,7 +579,7 @@ static PIDX_return_code create_midx(PIDX_io file, int svi)
     fprintf(midx_file, "<dataset typename='IdxMultipleDataset' mosaic='true'>\n");
     for (uint32_t i = 0; i < num_parts; i++)
     {
-      if(strcmp(file_name_skeleton,"") == 0) // skipe empty partitions
+      if(strcmp(file_name_skeleton,"") == 0) // skip empty partitions
         continue;
       
       uint64_t curr_off = i*PIDX_MAX_DIMENSIONS;


### PR DESCRIPTION
some zfp types (uint64 and int64) conflict with other libraries definition. 
I redefined them in all the code with zfp_[typename]