### PR TITLE
Particles position variable index

### DIFF
--- a/examples/basic-io/particle_read.c
+++ b/examples/basic-io/particle_read.c
@@ -86,7 +86,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#define DEBUG_PRINT_OUTPUT 1 
+#define DEBUG_PRINT_OUTPUT 1
+
+#define PARTICLES_POSITION_VAR 0
+#define PARTICLES_COLOR_VAR 1
 
 #if defined _MSC_VER
   #include "utils/PIDX_windows_utils.h"
@@ -252,12 +255,12 @@ int main(int argc, char **argv)
   for (uint32_t p = 0; p < checkpoint_particle_counts[0]; p++)
   {
     double px, py, pz;
-    memcpy(&px, (char*)checkpoint_data[0] + (p * 3 + 0) * sizeof(double), sizeof(double));
-    memcpy(&py, (char*)checkpoint_data[0] + (p * 3 + 1) * sizeof(double), sizeof(double));
-    memcpy(&pz, (char*)checkpoint_data[0] + (p * 3 + 2) * sizeof(double), sizeof(double));
+    memcpy(&px, (char*)checkpoint_data[PARTICLES_POSITION_VAR] + (p * 3 + 0) * sizeof(double), sizeof(double));
+    memcpy(&py, (char*)checkpoint_data[PARTICLES_POSITION_VAR] + (p * 3 + 1) * sizeof(double), sizeof(double));
+    memcpy(&pz, (char*)checkpoint_data[PARTICLES_POSITION_VAR] + (p * 3 + 2) * sizeof(double), sizeof(double));
 
     double d1;
-    memcpy(&d1, (char*)checkpoint_data[1] + (p) * sizeof(double), sizeof(double));
+    memcpy(&d1, (char*)checkpoint_data[PARTICLES_COLOR_VAR] + (p) * sizeof(double), sizeof(double));
 
     double d2;
     memcpy(&d2, (char*)checkpoint_data[2] + (p) * sizeof(double), sizeof(double));
@@ -315,11 +318,12 @@ int main(int argc, char **argv)
   
 #endif
   
+  // TODO fix error count
   int total_errors = 0;
-  MPI_Allreduce(&total_errors, &error_count, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-  
-  if(rank == 0)
-    printf("Error Count: %d\n", error_count);
+//  MPI_Allreduce(&error_count, &total_errors, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+//  
+//  if(rank == 0)
+    printf("Error Count: %d this %d\n", total_errors, error_count);
   
   free(data);
   if (checkpoint_restart)

--- a/examples/basic-io/particle_read.c
+++ b/examples/basic-io/particle_read.c
@@ -88,8 +88,8 @@
 
 #define DEBUG_PRINT_OUTPUT 1
 
-#define PARTICLES_POSITION_VAR 0
-#define PARTICLES_COLOR_VAR 1
+#define PARTICLES_POSITION_VAR 1
+#define PARTICLES_COLOR_VAR 0
 
 #if defined _MSC_VER
   #include "utils/PIDX_windows_utils.h"
@@ -249,8 +249,6 @@ int main(int argc, char **argv)
   char rank_filename[PATH_MAX];
   sprintf(rank_filename, "%s_r_%d", output_file_template, rank);
   FILE *fp = fopen(rank_filename, "w");
-
-  int ch1, ch2;
   
   for (uint32_t p = 0; p < checkpoint_particle_counts[0]; p++)
   {
@@ -290,13 +288,15 @@ int main(int argc, char **argv)
   
   fclose(fp);
   
+  int error_count = 0;
+  int ch1, ch2;
+
   // Verify output of read and write (TODO check for RST mode)
   char rank_filename_verify[PATH_MAX];
   sprintf(rank_filename_verify, "%s_w_%d", output_file_template, rank);
   FILE *fpv = fopen(rank_filename_verify, "r");
   fp = fopen(rank_filename, "r");
   
-  int error_count = 0;
   if (fpv == NULL || fp == NULL) {
     printf("Cannot verify rank %d looking for file %s and %s for reading ", rank, rank_filename, rank_filename_verify);
     exit(1);
@@ -307,10 +307,10 @@ int main(int argc, char **argv)
     while ((ch1 != EOF) && (ch2 != EOF) && (ch1 == ch2)) {
       ch1 = getc(fp);
       ch2 = getc(fpv);
-      
-      if(ch1 != ch2)
-        error_count++;
     }
+    
+    if(ch1 != ch2)
+      error_count++;
     
     fclose(fpv);
     fclose(fp);
@@ -318,12 +318,11 @@ int main(int argc, char **argv)
   
 #endif
   
-  // TODO fix error count
   int total_errors = 0;
-//  MPI_Allreduce(&error_count, &total_errors, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-//  
-//  if(rank == 0)
-    printf("Error Count: %d this %d\n", total_errors, error_count);
+  MPI_Allreduce(&error_count, &total_errors, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+  
+  if(rank == 0)
+    printf("Test Result: %s\n", total_errors > 0 ? "failed" : "success");
   
   free(data);
   if (checkpoint_restart)

--- a/examples/basic-io/particle_write.c
+++ b/examples/basic-io/particle_write.c
@@ -94,6 +94,8 @@
 
 #define DEBUG_PRINT_OUTPUT 1
 
+// these defines are to test different ordering
+// of the position variable
 #define PARTICLES_POSITION_VAR 1
 #define PARTICLES_COLOR_VAR 0
 
@@ -591,7 +593,7 @@ static void set_pidx_file(int ts)
   PIDX_set_current_time_step(file, ts);
   // Set the number of variables
   PIDX_set_variable_count(file, variable_count);
-  
+  // Set which variable will be used internally as position (default 0)
   PIDX_set_particles_position_variable_index(file, PARTICLES_POSITION_VAR);
 
   // Select I/O mode (PIDX_IDX_IO for the multires, PIDX_RAW_IO for non-multires)

--- a/pidx/PIDX.h
+++ b/pidx/PIDX.h
@@ -209,8 +209,13 @@ PIDX_return_code PIDX_set_variable_count(PIDX_file file, int  variable_count);
 ///
 PIDX_return_code PIDX_get_variable_count(PIDX_file file, int* variable_count);
 
-
-
+///
+/// Sets the index of variable containing the particles positions
+/// \param file The IDX file handler.
+/// \return The variable index.
+///
+PIDX_return_code PIDX_set_particles_position_variable_index(PIDX_file file, uint32_t var_index);
+  
 ///
 /// Sets the current time step for IDX file.
 /// The function should be used for time-varying dataset.

--- a/pidx/PIDX_file_create.c
+++ b/pidx/PIDX_file_create.c
@@ -177,6 +177,8 @@ PIDX_return_code PIDX_file_create(const char* filename, PIDX_flags flags, PIDX_a
   for (i=0;i<PIDX_MAX_DIMENSIONS;i++)
     (*file)->idx->chunk_size[i] = 1;
 
+  (*file)->idx->particles_position_variable_index = 0;
+  
   (*file)->idx->maxh = 0;
   (*file)->idx->max_file_count = 0;
   (*file)->fs_block_size = 0;

--- a/pidx/PIDX_file_open.c
+++ b/pidx/PIDX_file_open.c
@@ -233,6 +233,9 @@ PIDX_return_code PIDX_file_open(const char* filename, PIDX_flags flags, PIDX_acc
 
   if ((*file)->idx->io_type != PIDX_RAW_IO)
     (*file)->idx->samples_per_block = (int)pow(2, (*file)->idx->bits_per_block);
+  
+  if ((*file)->idx->io_type != PIDX_PARTICLE_IO || (*file)->idx->io_type != PIDX_RST_PARTICLE_IO)
+    MPI_Bcast(&((*file)->idx->particles_position_variable_index), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
 
   if ((*file)->idx_c->simulation_rank != 0)
   {

--- a/pidx/PIDX_idx_set_get.c
+++ b/pidx/PIDX_idx_set_get.c
@@ -91,7 +91,6 @@ PIDX_return_code PIDX_set_variable_count(PIDX_file file, int  variable_count)
 }
 
 
-
 PIDX_return_code PIDX_get_variable_count(PIDX_file file, int* variable_count)
 {
   if (!file)
@@ -102,6 +101,16 @@ PIDX_return_code PIDX_get_variable_count(PIDX_file file, int* variable_count)
   return PIDX_success;
 }
 
+
+PIDX_return_code PIDX_set_particles_position_variable_index(PIDX_file file, uint32_t var_index)
+{
+  if (!file)
+    return PIDX_err_file;
+  
+  file->idx->particles_position_variable_index = var_index;
+  
+  return PIDX_success;
+}
 
 
 PIDX_return_code PIDX_set_physical_dims(PIDX_file file, PIDX_physical_point dims)

--- a/pidx/core/PIDX_header/PIDX_header_io.c
+++ b/pidx/core/PIDX_header/PIDX_header_io.c
@@ -405,7 +405,7 @@ PIDX_return_code PIDX_header_io_global_idx_write (PIDX_header_io_id header_io, c
     else if (header_io->idx->io_type == PIDX_RAW_IO)
       fprintf(idx_file_p, "(io mode)\nraw\n");
     else if (header_io->idx->io_type == PIDX_PARTICLE_IO || header_io->idx->io_type == PIDX_RST_PARTICLE_IO)
-      fprintf(idx_file_p, "(io mode)\nparticle\n");
+      fprintf(idx_file_p, "(io mode)\nparticle\n(particles position var index)\n%d\n", header_io->idx->particles_position_variable_index);
 
     fprintf(idx_file_p, "(box)\n0 %lld 0 %lld 0 %lld 0 0 0 0\n", (long long)(header_io->idx->bounds[0] - 1), (long long)(header_io->idx->bounds[1] - 1), (long long)(header_io->idx->bounds[2] - 1));
     fprintf(idx_file_p, "(physical box)\n0 %f 0 %f 0 %f 0 0 0 0\n", header_io->idx->physical_bounds[0], header_io->idx->physical_bounds[1], header_io->idx->physical_bounds[2]);
@@ -419,7 +419,7 @@ PIDX_return_code PIDX_header_io_global_idx_write (PIDX_header_io_id header_io, c
 
     fprintf(idx_file_p, "(compression bit rate)\n%f\n", header_io->idx->compression_bit_rate);
     fprintf(idx_file_p, "(compression type)\n%d\n", header_io->idx->compression_type);
-
+    
     fprintf(idx_file_p, "(fields)\n");
     for (int l = 0; l < header_io->last_index; l++)
     {
@@ -525,8 +525,8 @@ PIDX_return_code PIDX_header_io_partition_idx_write (PIDX_header_io_id header_io
       fprintf(idx_file_p, "(io mode)\nl_part_idx\n");
     else if (header_io->idx->io_type == PIDX_RAW_IO)
       fprintf(idx_file_p, "(io mode)\nraw\n");
-    else if (header_io->idx->io_type == PIDX_PARTICLE_IO)
-      fprintf(idx_file_p, "(io mode)\nparticle\n");
+    else if (header_io->idx->io_type == PIDX_PARTICLE_IO || header_io->idx->io_type == PIDX_RST_PARTICLE_IO)
+      fprintf(idx_file_p, "(io mode)\nparticle\n(particles position var index)\n%d\n", header_io->idx->particles_position_variable_index);
 
     fprintf(idx_file_p, "(box)\n0 %lld 0 %lld 0 %lld 0 0 0 0\n", (long long)(header_io->idx->bounds[0] - 1), (long long)(header_io->idx->bounds[1] - 1), (long long)(header_io->idx->bounds[2] - 1));
 
@@ -653,7 +653,7 @@ PIDX_return_code PIDX_header_io_raw_idx_write (PIDX_header_io_id header_io, char
     else if (header_io->idx->io_type == PIDX_RAW_IO)
       fprintf(idx_file_p, "(io mode)\nraw\n");
     else if (header_io->idx->io_type == PIDX_PARTICLE_IO || header_io->idx->io_type == PIDX_RST_PARTICLE_IO)
-      fprintf(idx_file_p, "(io mode)\nparticle\n");
+      fprintf(idx_file_p, "(io mode)\nparticle\n(particles position var index)\n%d\n", header_io->idx->particles_position_variable_index);
 
     fprintf(idx_file_p, "(box)\n0 %lld 0 %lld 0 %lld 0 0 0 0\n", (long long)(header_io->idx->bounds[0] - 1), (long long)(header_io->idx->bounds[1] - 1), (long long)(header_io->idx->bounds[2] - 1));
     fprintf(idx_file_p, "(physical box)\n0 %f 0 %f 0 %f 0 0 0 0\n", header_io->idx->physical_bounds[0], header_io->idx->physical_bounds[1], header_io->idx->physical_bounds[2]);

--- a/pidx/core/PIDX_particles_rst/PIDX_particles_rst_meta_data.c
+++ b/pidx/core/PIDX_particles_rst/PIDX_particles_rst_meta_data.c
@@ -333,7 +333,7 @@ static PIDX_return_code populate_all_intersecting_restructured_super_patch_meta_
                   int pcount = 0;
                   for (uint64_t prc = 0; prc < rst_id->idx_metadata->variable[rst_id->first_index]->sim_patch[pc]->particle_count; ++prc)
                   {
-                    PIDX_variable pos_var = rst_id->idx_metadata->variable[rst_id->first_index];
+                    PIDX_variable pos_var = rst_id->idx_metadata->variable[rst_id->idx_metadata->particles_position_variable_index];
                     const uint64_t bytes_per_pos = pos_var->vps * pos_var->bpv/CHAR_BIT;
 
                     if (pointInChunk(reg_patch, (double*)(var0->sim_patch[pc]->buffer + prc * bytes_per_pos)))

--- a/pidx/data_handle/PIDX_idx_file_structs.h
+++ b/pidx/data_handle/PIDX_idx_file_structs.h
@@ -60,7 +60,7 @@ struct idx_file_struct
   int variable_tracker[512];                        /// Which one of the 256 variables are present
   PIDX_variable variable[512];                      /// pointer to variable
   uint32_t variable_count;                          /// The number of variables contained in the dataset
-
+  uint32_t particles_position_variable_index;       /// The index of the variable containing the particles position
 
   Agg_buffer **agg_buffer;                          /// aggregation related struct
 

--- a/pidx/io/particle/particle_vis_read.c
+++ b/pidx/io/particle/particle_vis_read.c
@@ -206,18 +206,17 @@ PIDX_return_code PIDX_particle_vis_read(PIDX_io file, int svi, int evi)
             }
           }
 
-          // TODO WILL: How do we know which variable the user has written as the "position" of
-          // particles, so that we can filter them by the box query?
           // QUESTION for SID: the setup for the sim patch count info doesn't make much sense
           // it seems. I'm not sure how the patches are added?
           // TODO FURTHERMORE: When we're reading and filtering the non-positional vars in
           // a box query we still need to know the positions of the particles to do the filtering
           // correctly. So regardless of what the user requests to read, we always must read the
           // positions
-          // TODO WILL: This assumes the first attribute being queried is the position and
-          // that it's a vec3d
-          PIDX_buffer *pos_var_buf = &tmp_var_read_bufs[0];
-          PIDX_variable pos_var = file->idx->variable[svi];
+          
+          // We use the "particles_position_variable_index" to know which variable contains
+          // the vector position data
+          PIDX_buffer *pos_var_buf = &tmp_var_read_bufs[file->idx->particles_position_variable_index];
+          PIDX_variable pos_var = file->idx->variable[file->idx->particles_position_variable_index];
           const uint64_t bytes_per_pos = pos_var->vps * pos_var->bpv/8;
 
           for (uint64_t i = 0; i < n_proc_patch->particle_count; ++i)

--- a/pidx/metadata/PIDX_metadata_parse_v6_1.c
+++ b/pidx/metadata/PIDX_metadata_parse_v6_1.c
@@ -196,6 +196,15 @@ PIDX_return_code PIDX_metadata_parse_v6_1(FILE *fp, PIDX_file* file)
       else if (strcmp(line,"big") == 0)
         (*file)->idx->endian = PIDX_BIG_ENDIAN;
     }
+    
+    if (strcmp(line, "(particles position var index)") == 0)
+    {
+      if ( fgets(line, sizeof line, fp) == NULL)
+        return PIDX_err_file;
+      line[strcspn(line, "\r\n")] = 0;
+      
+      (*file)->idx->particles_position_variable_index = atoi(line);
+    }
 
     if (strcmp(line, "(fields)") == 0)
     {


### PR DESCRIPTION
Use arbitrary variable as particles "position" variable.
The user can set it using:
PIDX_set_particles_position_variable_index(file, var_index);

Default var_index is 0.

The index is stored into the metadata and available as:
file->idx->particles_position_variable_index
