### PR TITLE
Fix time template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - HOMEBREW_CC=clang
         - HOMEBREW_CXX=clang++
         - BUILD_TYPE=Release
-        - MPIRUN_CMD="mpirun --oversubscribe"
+        - MPIRUN_CMD=mpirun
       
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s idx_read.app/Contents/MacOS/idx_read examples/idx_read; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s idx_write.app/Contents/MacOS/idx_write examples/idx_write; fi
   - cd ../tools/test
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python test.py -w 4 -r 4 -m $MPIRUN_CMD -t; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python test.py -w 2 -r 2 -m $MPIRUN_CMD -t; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python test.py -w 8 -r 8 -m $MPIRUN_CMD -t; fi
   - sh travis_tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - HOMEBREW_CC=clang
         - HOMEBREW_CXX=clang++
         - BUILD_TYPE=Release
-        - MPIRUN_CMD=mpirun --oversubscribe
+        - MPIRUN_CMD="mpirun --oversubscribe"
       
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s idx_read.app/Contents/MacOS/idx_read examples/idx_read; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s idx_write.app/Contents/MacOS/idx_write examples/idx_write; fi
   - cd ../tools/test
-  - python test.py -w 8 -r 8 -m $MPIRUN_CMD -t
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python test.py -w 4 -r 4 -m $MPIRUN_CMD -t; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python test.py -w 8 -r 8 -m $MPIRUN_CMD -t; fi
   - sh travis_tests.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s idx_read.app/Contents/MacOS/idx_read examples/idx_read; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s idx_write.app/Contents/MacOS/idx_write examples/idx_write; fi
   - cd ../tools/test
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python test.py -w 8 -r 8 -m $MPIRUN_CMD -t; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then python test.py -w 2 -r 2 -m $MPIRUN_CMD -t; fi
+  - python test.py -w 8 -r 8 -m $MPIRUN_CMD -t
   - sh travis_tests.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: c
 branches:
   only:
     - master
-    - refactor_dtypes
+    - fix_time_template
 
 cache:
   directories:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -97,7 +97,7 @@ IF (PIDX_BUILD_EXAMPLES)
   PIDX_ADD_CEXECUTABLE(idx_write_multibuffer "grids/idx_write_multibuffer.c")
   TARGET_LINK_LIBRARIES(idx_write_multibuffer ${EXAMPLES_LINK_LIBS})
 
-  PIDX_ADD_CEXECUTABLE(idx_checkpoint_restart "grids/idx_checkpoint_restart.cpp")
+  PIDX_ADD_CXXEXECUTABLE(idx_checkpoint_restart "grids/idx_checkpoint_restart.cpp")
   TARGET_LINK_LIBRARIES(idx_checkpoint_restart ${EXAMPLES_LINK_LIBS})
 
 # Experimental reduced resolution

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -97,6 +97,9 @@ IF (PIDX_BUILD_EXAMPLES)
   PIDX_ADD_CEXECUTABLE(idx_write_multibuffer "grids/idx_write_multibuffer.c")
   TARGET_LINK_LIBRARIES(idx_write_multibuffer ${EXAMPLES_LINK_LIBS})
 
+  PIDX_ADD_CEXECUTABLE(idx_checkpoint_restart "grids/idx_checkpoint_restart.cpp")
+  TARGET_LINK_LIBRARIES(idx_checkpoint_restart ${EXAMPLES_LINK_LIBS})
+
 # Experimental reduced resolution
 #  PIDX_ADD_CEXECUTABLE(idx_write_reduce_resolution "experimental/reduced_resolution/idx_write_reduced_resolution.c")
 #  TARGET_LINK_LIBRARIES(idx_write_reduce_resolution ${EXAMPLES_LINK_LIBS})

--- a/examples/experimental/reduced_resolution/idx_write_reduced_resolution.c
+++ b/examples/experimental/reduced_resolution/idx_write_reduced_resolution.c
@@ -318,32 +318,32 @@ static void create_synthetic_simulation_data()
 
           for (val_per_sample = 0; val_per_sample < vps[var]; val_per_sample++)
           {
-            if (strcmp(type_name[var], UINT8) == 0 || strcmp(type_name[var], UINT8_GA) == 0 || strcmp(type_name[var], UINT8_RGB) == 0)
+            if (strcmp(type_name[var], PIDX_DType.UINT8) == 0 || strcmp(type_name[var], PIDX_DType.UINT8_GA) == 0 || strcmp(type_name[var], PIDX_DType.UINT8_RGB) == 0)
             {
               cvalue = (int)(var + val_per_sample + ((global_box_size[X] * global_box_size[Y]*(local_box_offset[Z] + k))+(global_box_size[X]*(local_box_offset[Y] + j)) + (local_box_offset[X] + i)));
               memcpy(data[var] + (index * vps[var] + val_per_sample) * sizeof(unsigned char), &cvalue, sizeof(unsigned char));
             }
-            if (strcmp(type_name[var], INT16) == 0 || strcmp(type_name[var], INT16_GA) == 0 || strcmp(type_name[var], INT16_RGB) == 0)
+            if (strcmp(type_name[var], PIDX_DType.INT16) == 0 || strcmp(type_name[var], PIDX_DType.INT16_GA) == 0 || strcmp(type_name[var], PIDX_DType.INT16_RGB) == 0)
             {
               svalue = (int)(var + val_per_sample + ((global_box_size[X] * global_box_size[Y]*(local_box_offset[Z] + k))+(global_box_size[X]*(local_box_offset[Y] + j)) + (local_box_offset[X] + i)));
               memcpy(data[var] + (index * vps[var] + val_per_sample) * sizeof(short), &svalue, sizeof(short));
             }
-            if (strcmp(type_name[var], INT32) == 0 || strcmp(type_name[var], INT32_GA) == 0 || strcmp(type_name[var], INT32_RGB) == 0)
+            if (strcmp(type_name[var], PIDX_DType.INT32) == 0 || strcmp(type_name[var], PIDX_DType.INT32_GA) == 0 || strcmp(type_name[var], PIDX_DType.INT32_RGB) == 0)
             {
               ivalue = (int)( 100 + var + val_per_sample + ((global_box_size[X] * global_box_size[Y]*(local_box_offset[Z] + k))+(global_box_size[X]*(local_box_offset[Y] + j)) + (local_box_offset[X] + i)));
               memcpy(data[var] + (index * vps[var] + val_per_sample) * sizeof(int), &ivalue, sizeof(int));
             }
-            else if (strcmp(type_name[var], FLOAT32) == 0 || strcmp(type_name[var], FLOAT32_GA) == 0 || strcmp(type_name[var], FLOAT32_RGB) == 0)
+            else if (strcmp(type_name[var], PIDX_DType.FLOAT32) == 0 || strcmp(type_name[var], PIDX_DType.FLOAT32_GA) == 0 || strcmp(type_name[var], PIDX_DType.FLOAT32_RGB) == 0)
             {
               fvalue = (float)( 100 + var + val_per_sample + ((global_box_size[X] * global_box_size[Y]*(local_box_offset[Z] + k))+(global_box_size[X]*(local_box_offset[Y] + j)) + (local_box_offset[X] + i)));
               memcpy(data[var] + (index * vps[var] + val_per_sample) * sizeof(float), &fvalue, sizeof(float));
             }
-            else if (strcmp(type_name[var], FLOAT64) == 0 || strcmp(type_name[var], FLOAT64_GA) == 0 || strcmp(type_name[var], FLOAT64_RGB) == 0)
+            else if (strcmp(type_name[var], PIDX_DType.FLOAT64) == 0 || strcmp(type_name[var], PIDX_DType.FLOAT64_GA) == 0 || strcmp(type_name[var], PIDX_DType.FLOAT64_RGB) == 0)
             {
               dvalue = (double) 100 + var + val_per_sample + ((global_box_size[X] * global_box_size[Y]*(local_box_offset[Z] + k))+(global_box_size[X]*(local_box_offset[Y] + j)) + (local_box_offset[X] + i));
               memcpy(data[var] + (index * vps[var] + val_per_sample) * sizeof(double), &dvalue, sizeof(double));
             }
-            else if (strcmp(type_name[var], UINT64) == 0 || strcmp(type_name[var], UINT64_GA) == 0 || strcmp(type_name[var], UINT64_RGB) == 0)
+            else if (strcmp(type_name[var], PIDX_DType.UINT64) == 0 || strcmp(type_name[var], PIDX_DType.UINT64_GA) == 0 || strcmp(type_name[var], PIDX_DType.UINT64_RGB) == 0)
             {
               uivalue = (uint64_t) 100 + var + val_per_sample + ((global_box_size[X] * global_box_size[Y]*(local_box_offset[Z] + k))+(global_box_size[X]*(local_box_offset[Y] + j)) + (local_box_offset[X] + i));
               memcpy(data[var] + (index * vps[var] + val_per_sample) * sizeof(uint64_t), &uivalue, sizeof(uint64_t));

--- a/examples/grids/idx_checkpoint_restart.cpp
+++ b/examples/grids/idx_checkpoint_restart.cpp
@@ -384,7 +384,7 @@ int main(int argc, char** argv){
     for(; t < max_t; t++){
 
         // Generate data for Checkpoint dump
-        int checkpoint_variable_count = 3;                           //< How many variables
+        const int checkpoint_variable_count = 3;            //< How many variables
         int checkpoint_vps[checkpoint_variable_count];      //< How many values per sample
         checkpoint_vps[0] = 1;
         checkpoint_vps[1] = 1;
@@ -409,7 +409,7 @@ int main(int argc, char** argv){
 #ifdef VIS_DUMP
         // Vis DUMP with downcasting
 
-        int vis_variable_count = 1;                             //< How many variables
+        const int vis_variable_count = 1;                             //< How many variables
         int vis_vps[vis_variable_count];          //< How many values per sample
         vis_vps[0] = 1;
 

--- a/examples/grids/idx_checkpoint_restart.cpp
+++ b/examples/grids/idx_checkpoint_restart.cpp
@@ -38,11 +38,17 @@
  * For support: support@visus.net
  * 
  */
-//#include <unistd.h>
-//#include <stdarg.h>
-//#include <stdint.h>
-#include <string>
+#if !defined _MSC_VER
+#include <unistd.h>
+#endif
+#include <stdarg.h>
+#include <stdint.h>
+#include <ctype.h>
 #include <PIDX.h>
+
+#if defined _MSC_VER
+#include "utils/PIDX_windows_utils.h"
+#endif
 
 #define VIS_DUMP // << ENABLE Visualization dump with downcasting
 

--- a/examples/grids/idx_checkpoint_restart.cpp
+++ b/examples/grids/idx_checkpoint_restart.cpp
@@ -457,8 +457,6 @@ int main(int argc, char** argv){
     return 0;
 }
 
-
-///< Parse the input arguments
 static int parse_args(int argc, char **argv)
 {
     char flags[] = "g:l:r:";
@@ -469,19 +467,25 @@ static int parse_args(int argc, char **argv)
         /* postpone error checking for after while loop */
         switch (one_opt)
         {
-            case('g'):
-                sscanf(optarg, "%dx%dx%d", &global_box_size[0], &global_box_size[1], &global_box_size[2]);
-                break;
-            case('l'):
-                sscanf(optarg, "%dx%dx%d", &local_box_size[0], &local_box_size[1], &local_box_size[2]);
-                break;
-            case('r'):
-                sscanf(optarg, "%dx", &restart_time);
-                break;
-            case('?'):
-                return (-1);
+            case('g'): // global dimension
+                if ((sscanf(optarg, "%lldx%lldx%lld", &global_box_size[0], &global_box_size[1], &global_box_size[2]) == EOF) || (global_box_size[0] < 1 || global_box_size[1] < 1 || global_box_size[2] < 1))
+                    fprintf(stderr,"Invalid global dimensions\n%s", usage);
+            break;
+
+            case('l'): // local dimension
+                if ((sscanf(optarg, "%lldx%lldx%lld", &local_box_size[0], &local_box_size[1], &local_box_size[2]) == EOF) || (local_box_size[0] < 1 || local_box_size[1] < 1 || local_box_size[2] < 1))
+                    fprintf(stderr,"Invalid local dimension\n%s", usage);
+            break;
+
+            case('r'): // number of variables
+                sscanf(optarg, "%d", &restart_time);
+            break;
+
+            default:
+                fprintf(stderr,"Wrong arguments\n%s", usage);
         }
     }
+
     /* need positive dimensions */
     if (global_box_size[0] < 1 || global_box_size[1] < 1 || global_box_size[2] < 1 || local_box_size[0] < 1 || local_box_size[1] < 1 || local_box_size[2] < 1)
     {
@@ -508,7 +512,7 @@ static int parse_args(int argc, char **argv)
         return (-1);
     }
 
-    return (0);
+    return 0;
 }
 
 ///< How to use this progam

--- a/examples/grids/idx_checkpoint_restart.cpp
+++ b/examples/grids/idx_checkpoint_restart.cpp
@@ -1,0 +1,535 @@
+/*
+ * BSD 3-Clause License
+ * 
+ * Copyright (c) 2010-2018 ViSUS L.L.C., 
+ * Scientific Computing and Imaging Institute of the University of Utah
+ * 
+ * ViSUS L.L.C., 50 W. Broadway, Ste. 300, 84101-2044 Salt Lake City, UT
+ * University of Utah, 72 S Central Campus Dr, Room 3750, 84112 Salt Lake City, UT
+ *  
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 
+ * * Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * For additional information about this project contact: pascucci@acm.org
+ * For support: support@visus.net
+ * 
+ */
+//#include <unistd.h>
+//#include <stdarg.h>
+//#include <stdint.h>
+#include <string>
+#include <PIDX.h>
+
+#define VIS_DUMP // << ENABLE Visualization dump with downcasting
+
+
+static int parse_args(int argc, char **argv);
+static void usage(void);
+static void report_error(std::string func_name, std::string file_name, int line_no);
+
+static const int bits_per_block = 16;
+static const int blocks_per_file = 256;
+static int global_box_size[3] = {0, 0, 0};            ///< global dimensions of 3D volume
+static int local_box_size[3] = {0, 0, 0};             ///< local dimensions of the per-process block
+static PIDX_point global_size, local_offset, local_size;
+static int local_box_offset[3];
+static int restart_time = -1;
+static int nprocs = 1, rank = 0;
+
+int init(int argc, char **argv){
+
+    int ret;
+
+    // MPI initialization
+#if PIDX_HAVE_MPI
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
+
+    if (rank == 0)
+    {
+        ret = parse_args(argc, argv);
+        if (ret < 0)
+        {
+            usage();
+#if PIDX_HAVE_MPI
+            MPI_Abort(MPI_COMM_WORLD, -1);
+#else
+            exit(-1);
+#endif
+        }
+
+        // check if the num procs is appropriate
+        int num_bricks = (global_box_size[0] / local_box_size[0]) * (global_box_size[1] / local_box_size[1]) * (global_box_size[2] / local_box_size[2]);
+        if(num_bricks != nprocs)
+        {
+            fprintf(stderr, "Error: number of sub-blocks (%d) doesn't match number of procs (%d)\n", num_bricks, nprocs);
+            fprintf(stderr, "Incorrect distribution of data across processes i.e.\n(global_x / local_x) X (global_x / local_x) X (global_x / local_x) != nprocs\n(%d/%d) X (%d/%d) X (%d/%d) != %d\n", global_box_size[0], local_box_size[0], global_box_size[1], local_box_size[1], global_box_size[2], local_box_size[2], nprocs);
+
+#if PIDX_HAVE_MPI
+            MPI_Abort(MPI_COMM_WORLD, -1);
+#else
+            exit(-1);
+#endif
+        }
+    }
+
+#if PIDX_HAVE_MPI
+    MPI_Bcast(global_box_size, 3, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(local_box_size, 3, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&restart_time, 1, MPI_INT, 0, MPI_COMM_WORLD);
+#endif
+
+    // Calculating every process data's offset and size
+    int sub_div[3];
+    sub_div[0] = (global_box_size[0] / local_box_size[0]);
+    sub_div[1] = (global_box_size[1] / local_box_size[1]);
+    sub_div[2] = (global_box_size[2] / local_box_size[2]);
+    local_box_offset[2] = (rank / (sub_div[0] * sub_div[1])) * local_box_size[2];
+    int slice = rank % (sub_div[0] * sub_div[1]);
+    local_box_offset[1] = (slice / sub_div[0]) * local_box_size[1];
+    local_box_offset[0] = (slice % sub_div[0]) * local_box_size[0];
+
+    PIDX_set_point(global_size, global_box_size[0], global_box_size[1], global_box_size[2]);
+    PIDX_set_point(local_offset, local_box_offset[0], local_box_offset[1], local_box_offset[2]);
+    PIDX_set_point(local_size, local_box_size[0], local_box_size[1], local_box_size[2]);
+
+    return 0;
+
+}
+
+// Create a 3D sin function as example of synthetic simulation data (change phase over time)
+template<typename T>
+int create_data(T** data, unsigned variable_count, int* vps1, int ts){
+    double fsize = 16.0;
+    double fratiox = (fsize)/global_box_size[0];
+    double fratioy = (fsize)/global_box_size[1];
+    double fratioz = (fsize)/global_box_size[2];
+
+    for(unsigned var = 0; var < variable_count; var++)
+    {
+        fsize = fsize * (var+1); // change freq for different variables
+
+        data[var] = (double*)malloc(sizeof (T) * local_box_size[0] * local_box_size[1] * local_box_size[2]  * vps1[var]);
+
+        for (int k = 0; k < local_box_size[2]; k++)
+        {
+            for (int j = 0; j < local_box_size[1]; j++)
+            {
+                for (int i = 0; i < local_box_size[0]; i++)
+                {
+                    unsigned long long index = (unsigned long long) (local_box_size[0] * local_box_size[1] * k) + (local_box_size[0] * j) + i;
+                    for (int vps = 0; vps < vps1[var]; vps++){
+                        double xc = (i + local_box_offset[0])*fratiox - fsize/2;
+                        double yc = (j + local_box_offset[1])*fratioy - fsize/2;
+                        double zc = (k + local_box_offset[2])*fratioz;
+                        double zv = sin((xc*xc + yc*yc + ts%180)*3.14159265359/180)* fsize/2 + fsize/2;
+
+                        if(zc > zv-0.7 && zc < zv+0.7)
+                            data[var][index * vps1[var] + vps] = zv*global_box_size[2];
+                        else
+                            data[var][index * vps1[var] + vps] = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    return 0;
+
+}
+
+// Read the data in the current IDX file at a defined time step,
+// useful to check the information about the last checkpoint and then restart the simulation
+int check_last_state(std::string file_name, int ts){
+    //  Creating access
+    PIDX_access access;
+    PIDX_create_access(&access);
+#if PIDX_HAVE_MPI
+    PIDX_set_mpi_access(access, MPI_COMM_WORLD);
+#endif
+    int variable_count, ret;
+
+    PIDX_file file;            // IDX file descriptor
+    PIDX_variable* variable;   // variable descriptor
+    PIDX_point dims;
+
+    ret = PIDX_file_open(file_name.c_str(), PIDX_MODE_RDONLY, access, dims, &file);
+    if (ret != PIDX_success)  report_error("PIDX_file_open", __FILE__, __LINE__);
+
+    ret = PIDX_get_variable_count(file, &variable_count);
+    if (ret != PIDX_success)  report_error("PIDX_set_variable_count", __FILE__, __LINE__);
+
+    if(rank == 0){
+        printf("Restart reading last state:\n\tvariable count: %d\n", variable_count);
+    }
+
+    ret = PIDX_set_current_time_step(file, ts);
+    if (ret != PIDX_success)  report_error("PIDX_get_current_time_step", __FILE__, __LINE__);
+
+    variable = (PIDX_variable*)malloc(sizeof(*variable) * variable_count);
+    memset(variable, 0, sizeof(*variable) * variable_count);
+
+    int* vps = (int*)malloc(sizeof(*vps) * variable_count);
+    memset(vps, 0, sizeof(*vps) * variable_count);
+
+    double** data = (double**)malloc(sizeof(*data) * variable_count);
+    memset(data, 0, sizeof(*data) * variable_count);
+
+    for (int var = 0; var < variable_count; var++)
+    {
+        ret = PIDX_get_next_variable(file, &variable[var]);
+        if (ret != PIDX_success) report_error("PIDX_get_next_variable", __FILE__, __LINE__);
+
+        vps[var] = variable[var]->vps;
+
+        int values_per_sample = 0;
+        int bits_per_sample = 0;
+        PIDX_values_per_datatype(variable[var]->type_name, &values_per_sample, &bits_per_sample);
+
+        if(rank == 0){
+            printf("\t variable %d values per sample %d bits per sample %d \n", var, vps[var], bits_per_sample);
+        }
+
+        data[var] = (double*)malloc((bits_per_sample/8) * local_box_size[0] * local_box_size[1] * local_box_size[2]  * values_per_sample);
+        memset(data[var], 0, (bits_per_sample/8) * local_box_size[0] * local_box_size[1] * local_box_size[2]  * values_per_sample);
+
+        ret = PIDX_variable_read_data_layout(variable[var], local_offset, local_size, data[var], PIDX_row_major);
+        if (ret != PIDX_success)  report_error("PIDX_variable_read_data_layout", __FILE__, __LINE__);
+
+        ret = PIDX_read_next_variable(file, variable[var]);
+        if (ret != PIDX_success)  report_error("PIDX_read_next_variable", __FILE__, __LINE__);
+    }
+
+//    ret = PIDX_reset_variable_counter(file);
+//    if (ret != PIDX_success)  report_error("PIDX_reset_variable_counter", __FILE__, __LINE__);
+//
+//    for (int var = 0; var < variable_count; var++)
+//    {
+//        ret = PIDX_get_next_variable(file, &variable[var]);
+//        if (ret != PIDX_success)  report_error("PIDX_get_next_variable", __FILE__, __LINE__);
+//
+//        ret = PIDX_variable_read_data_layout(variable[var], local_offset, local_size, data[var], PIDX_row_major);
+//        if (ret != PIDX_success)  report_error("PIDX_variable_read_data_layout", __FILE__, __LINE__);
+//
+//        ret = PIDX_read_next_variable(file, variable[var]);
+//        if (ret != PIDX_success)  report_error("PIDX_read_next_variable", __FILE__, __LINE__);
+//    }
+
+    ret = PIDX_close(file);
+    if (ret != PIDX_success)  report_error("PIDX_close", __FILE__, __LINE__);
+
+    ret = PIDX_close_access(access);
+    if (ret != PIDX_success)  report_error("PIDX_close_access", __FILE__, __LINE__);
+
+    for(int var = 0; var < variable_count; var++)
+    {
+        free(data[var]);
+        data[var] = 0;
+    }
+    free(data);
+
+    return 0;
+
+}
+
+int open_file(PIDX_file& file, PIDX_access& access, std::string output_filename){
+    int ret = 1;
+
+    if(restart_time > 0)
+    {
+        ret = PIDX_file_open(output_filename.c_str(), PIDX_MODE_RDWR, access, global_size, &file);
+        if (ret != PIDX_success)  report_error("PIDX_file_open", __FILE__, __LINE__);
+    }
+    else
+    {
+        ret = PIDX_file_create(output_filename.c_str(), PIDX_MODE_CREATE, access, global_size, &file);
+        if (ret != PIDX_success)  report_error("PIDX_file_create", __FILE__, __LINE__);
+        PIDX_set_block_size(file, bits_per_block);
+        PIDX_set_block_count(file, blocks_per_file);
+
+    }
+
+    return ret;
+
+}
+
+// Dump the data with PIDX
+template<typename T>
+int write_data(T** data, PIDX_file& file, PIDX_access& access, int ts, int variable_count, int* vps, std::string output_file_name, std::string var_prefix, PIDX_data_type data_type){
+
+    int ret = 0;
+
+    PIDX_variable* variable;   // variable descriptor
+    variable = (PIDX_variable*)malloc(sizeof(*variable) * variable_count);
+    memset(variable, 0, sizeof(*variable) * variable_count);
+
+    open_file(file, access, output_file_name);
+
+    ret = PIDX_set_current_time_step(file, ts);
+    if (ret != PIDX_success)  report_error("PIDX_set_current_time_step", __FILE__, __LINE__);
+    ret = PIDX_set_variable_count(file, variable_count);
+    if (ret != PIDX_success)  report_error("PIDX_set_variable_count", __FILE__, __LINE__);
+
+    char var_name[512];
+    for (int var = 0; var < variable_count; var++)
+    {
+        sprintf(var_name, var_prefix.c_str(), var);
+
+        ret = PIDX_variable_create(var_name, vps[var] * sizeof(T) * 8, data_type, &variable[var]);
+        if (ret != PIDX_success)  report_error("PIDX_variable_create", __FILE__, __LINE__);
+        ret = PIDX_variable_write_data_layout(variable[var], local_offset, local_size, data[var], PIDX_row_major);
+        if (ret != PIDX_success)  report_error("PIDX_variable_data_layout", __FILE__, __LINE__);
+        ret = PIDX_append_and_write_variable(file, variable[var]);
+        if (ret != PIDX_success)  report_error("PIDX_append_and_write_variable", __FILE__, __LINE__);
+
+    }
+
+    ret = PIDX_close(file);
+    if (ret != PIDX_success)  report_error("PIDX_close", __FILE__, __LINE__);
+
+    delete [] variable;
+
+    return ret;
+
+}
+
+
+// Simple downcast from the checkpoint_data (double) to a downcasted version (float)
+void downcast_checkpoint(double** checkpoint_data, float** vis_data,
+                            int cp_var_idx, int vis_var_idx, int len){
+
+    vis_data[vis_var_idx] = (float*)malloc(sizeof(float) * len);
+
+    for(int i=0; i < len; i++){
+        vis_data[vis_var_idx][i] = (float)(checkpoint_data[cp_var_idx][i]);
+    }
+}
+
+int main(int argc, char** argv){
+    // Initialize PIDX
+    init(argc, argv);
+
+    const unsigned checkpoint_t_period = 10;    // checkpoint period
+    const unsigned vis_t_period = 5;            // visualization (downcasted) dump period
+    const unsigned max_t = 500;                 // total number of timesteps of the simulation
+
+    std::string checkpoint_filename = "checkpoint.idx";
+    std::string vis_filename = "vis.idx";
+
+    unsigned t = 0;
+
+    // if a restart timestep has been specified
+    // check the checkpoint data and restart the simulation from this time
+    if(restart_time > 0){
+        t = restart_time; // set current simulation time to the restarting time
+        check_last_state(checkpoint_filename, t/checkpoint_t_period);
+
+    }else{ // No restart, so the simulation will start from t=0
+        t = 0;
+    }
+
+    if(rank == 0){
+        printf("Start from t = %d\n", t);
+    }
+
+#ifdef VIS_DUMP
+
+    // Define file descriptor and access for visualization dump
+    PIDX_file vis_file;
+    PIDX_access vis_access;
+    PIDX_create_access(&vis_access);
+
+ #if PIDX_HAVE_MPI
+    PIDX_set_mpi_access(vis_access, MPI_COMM_WORLD);
+ #endif
+
+#endif
+
+    // Define file descriptor and access for checkpoint dump
+    PIDX_file checkpoint_file;
+    PIDX_access checkpoint_access;
+    PIDX_create_access(&checkpoint_access);
+
+#if PIDX_HAVE_MPI
+    PIDX_set_mpi_access(checkpoint_access, MPI_COMM_WORLD);
+#endif
+
+    // Main simulation loop
+    for(; t < max_t; t++){
+
+        // Generate data for Checkpoint dump
+        int checkpoint_variable_count = 3;                           //< How many variables
+        int checkpoint_vps[checkpoint_variable_count];      //< How many values per sample
+        checkpoint_vps[0] = 1;
+        checkpoint_vps[1] = 1;
+        checkpoint_vps[2] = 1;
+
+        double** checkpoint_data = (double**)malloc(sizeof(*checkpoint_data) * checkpoint_variable_count);
+        memset(checkpoint_data, 0, sizeof(*checkpoint_data) * checkpoint_variable_count);
+
+        // Create syntethic data for the checkpoint
+        double t1, t2;
+        t1 = MPI_Wtime();
+        create_data<double>(checkpoint_data, checkpoint_variable_count, checkpoint_vps, t);
+        t2 = MPI_Wtime();
+
+        if(rank == 0)
+            printf( "Generating state data time is %f\n", t2 - t1 );
+
+        if(t % checkpoint_t_period == 0){
+            write_data(checkpoint_data, checkpoint_file, checkpoint_access, t/checkpoint_t_period, checkpoint_variable_count, checkpoint_vps, checkpoint_filename, "state_var_%d", PIDX_DType.FLOAT64);
+        }
+
+#ifdef VIS_DUMP
+        // Vis DUMP with downcasting
+
+        int vis_variable_count = 1;                             //< How many variables
+        int vis_vps[vis_variable_count];          //< How many values per sample
+        vis_vps[0] = 1;
+
+        float** vis_data = (float**)malloc(sizeof(*vis_data) * vis_variable_count);
+        memset(vis_data, 0, sizeof(*vis_data) * vis_variable_count);
+
+        // downcast check point data
+        downcast_checkpoint(checkpoint_data, vis_data, 0, 0, local_box_size[0]*local_box_size[1]*local_box_size[2]);
+
+        // dump visualization data
+        if(t % vis_t_period == 0){
+            write_data(vis_data, vis_file, vis_access, t/vis_t_period, vis_variable_count, vis_vps, vis_filename, "data_var_%d", PIDX_DType.FLOAT32);
+        }
+
+        delete [] vis_data[0];
+        delete [] vis_data;
+#endif
+
+        if(rank == 0)
+        {
+            printf("time %d\n", t);
+        }
+        //sleep(1);
+
+        for(int varidx=0; varidx < checkpoint_variable_count; varidx++)
+            delete [] checkpoint_data[varidx];
+
+        delete [] checkpoint_data;
+
+    }
+
+    int ret = PIDX_close_access(checkpoint_access);
+    if (ret != PIDX_success)  report_error("PIDX_close_access state", __FILE__, __LINE__);
+
+#ifdef VIS_DUMP
+    ret = PIDX_close_access(vis_access);
+    if (ret != PIDX_success)  report_error("PIDX_close_access data", __FILE__, __LINE__);
+#endif
+
+    //  MPI finalize
+#if PIDX_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return 0;
+}
+
+
+///< Parse the input arguments
+static int parse_args(int argc, char **argv)
+{
+    char flags[] = "g:l:r:";
+    int one_opt = 0;
+
+    while ((one_opt = getopt(argc, argv, flags)) != EOF)
+    {
+        /* postpone error checking for after while loop */
+        switch (one_opt)
+        {
+            case('g'):
+                sscanf(optarg, "%dx%dx%d", &global_box_size[0], &global_box_size[1], &global_box_size[2]);
+                break;
+            case('l'):
+                sscanf(optarg, "%dx%dx%d", &local_box_size[0], &local_box_size[1], &local_box_size[2]);
+                break;
+            case('r'):
+                sscanf(optarg, "%dx", &restart_time);
+                break;
+            case('?'):
+                return (-1);
+        }
+    }
+    /* need positive dimensions */
+    if (global_box_size[0] < 1 || global_box_size[1] < 1 || global_box_size[2] < 1 || local_box_size[0] < 1 || local_box_size[1] < 1 || local_box_size[2] < 1)
+    {
+        fprintf(stderr, "Error: bad dimension specification.\n");
+        return (-1);
+    }
+
+    /* need global dimension to be larger than the local */
+    if (global_box_size[0] < local_box_size[0] || global_box_size[1] < local_box_size[1] || global_box_size[2] < local_box_size[2])
+    {
+        fprintf(stderr, "Error: Per-process local box size cannot be greater than the global box\n");
+        return (-1);
+    }
+
+    if (local_box_size[0] == 0 || local_box_size[1] == 0 || local_box_size[2] == 0)
+    {
+        fprintf(stderr, "Local Dimension cannot be 0!!!!!!!!!\n");
+        return (-1);
+    }
+
+    if (global_box_size[0] == 0 || global_box_size[1] == 0 || global_box_size[2] == 0)
+    {
+        fprintf(stderr, "Global Dimension cannot be 0!!!!!!!!!\n");
+        return (-1);
+    }
+
+    return (0);
+}
+
+///< How to use this progam
+static void usage(void)
+{
+    printf("Serial Usage: ./idx_checkpoint_restart -g 64x64x128 -l 64x64x128 [-r restart_timestep]\n");
+    printf("Parallel Usage: mpirun -n 8 ./idx_checkpoint_restart -g 64x64x128 -l 32x32x64 [-r restart_timestep]\n");
+    printf("  -g: global dimensions\n");
+    printf("  -l: local (per-process) dimensions\n");
+    printf("\n");
+
+    return;
+}
+
+///< Print error and exit program
+static void report_error(std::string func_name, std::string file_name, int line_no)
+{
+    fprintf(stderr, "Error in function %s Program %s Line %d\n", func_name.c_str(), file_name.c_str(), line_no);
+#if PIDX_HAVE_MPI
+    MPI_Abort(MPI_COMM_WORLD, -1);
+#else
+    exit(-1);
+#endif
+}

--- a/examples/grids/idx_checkpoint_restart.cpp
+++ b/examples/grids/idx_checkpoint_restart.cpp
@@ -41,6 +41,7 @@
 #if !defined _MSC_VER
 #include <unistd.h>
 #endif
+#include <string>
 #include <stdarg.h>
 #include <stdint.h>
 #include <ctype.h>

--- a/pidx/PIDX_data_types.c
+++ b/pidx/PIDX_data_types.c
@@ -106,6 +106,8 @@ PIDX_return_code PIDX_default_bits_per_datatype(PIDX_data_type type, int* bits)
 {
   char full_typename[64];
   strncpy(full_typename, type, 64);
+  // if typename does not start with the number of components change to "1*dataype"
+  // TODO handle also case with datatype written as datatype[n_comp]
   if(!isdigit(full_typename[0])){
     sprintf(full_typename, "1*%s", type);
   }

--- a/pidx/PIDX_data_types.c
+++ b/pidx/PIDX_data_types.c
@@ -39,6 +39,8 @@
  * 
  */
 
+#include <ctype.h>
+
 #include "PIDX_file_handler.h"
 
 struct pidx_dtype PIDX_DType = {
@@ -102,102 +104,108 @@ struct pidx_dtype PIDX_DType = {
 
 PIDX_return_code PIDX_default_bits_per_datatype(PIDX_data_type type, int* bits)
 {
-  if (strcmp(type, PIDX_DType.INT8) == 0)
+  char full_typename[64];
+  strncpy(full_typename, type, 64);
+  if(!isdigit(full_typename[0])){
+    sprintf(full_typename, "1*%s", type);
+  }
+
+  if (strcmp(full_typename, PIDX_DType.INT8) == 0)
     *bits = 8;
-  else if (strcmp(type, PIDX_DType.INT8_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT8_GA) == 0)
     *bits = 16;
-  else if (strcmp(type, PIDX_DType.INT8_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT8_RGB) == 0)
     *bits = 24;
-  else if (strcmp(type, PIDX_DType.INT8_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT8_RGBA) == 0)
     *bits = 32;
 
-  else if (strcmp(type, PIDX_DType.UINT8) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT8) == 0)
     *bits = 8;
-  else if (strcmp(type, PIDX_DType.UINT8_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT8_GA) == 0)
     *bits = 16;
-  else if (strcmp(type, PIDX_DType.UINT8_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT8_RGB) == 0)
     *bits = 24;
-  else if (strcmp(type, PIDX_DType.UINT8_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT8_RGBA) == 0)
     *bits = 32;
 
-  else if (strcmp(type, PIDX_DType.INT16) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT16) == 0)
     *bits = 16;
-  else if (strcmp(type, PIDX_DType.INT16_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT16_GA) == 0)
     *bits = 32;
-  else if (strcmp(type, PIDX_DType.INT16_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT16_RGB) == 0)
     *bits = 48;
-  else if (strcmp(type, PIDX_DType.INT16_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT16_RGBA) == 0)
     *bits = 64;
 
-  else if (strcmp(type, PIDX_DType.UINT16) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT16) == 0)
     *bits = 16;
-  else if (strcmp(type, PIDX_DType.UINT16_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT16_GA) == 0)
     *bits = 32;
-  else if (strcmp(type, PIDX_DType.UINT16_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT16_RGB) == 0)
     *bits = 48;
-  else if (strcmp(type, PIDX_DType.UINT16_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT16_RGBA) == 0)
     *bits = 64;
 
-  else if (strcmp(type, PIDX_DType.INT32) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT32) == 0)
     *bits = 32;
-  else if (strcmp(type, PIDX_DType.INT32_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT32_GA) == 0)
     *bits = 64;
-  else if (strcmp(type, PIDX_DType.INT32_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT32_RGB) == 0)
     *bits = 96;
-  else if (strcmp(type, PIDX_DType.INT32_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT32_RGBA) == 0)
     *bits = 128;
 
-  else if (strcmp(type, PIDX_DType.UINT32) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT32) == 0)
     *bits = 32;
-  else if (strcmp(type, PIDX_DType.UINT32_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT32_GA) == 0)
     *bits = 64;
-  else if (strcmp(type, PIDX_DType.UINT32_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT32_RGB) == 0)
     *bits = 96;
-  else if (strcmp(type, PIDX_DType.UINT32_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT32_RGBA) == 0)
     *bits = 128;
 
-  else if (strcmp(type, PIDX_DType.INT64) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT64) == 0)
     *bits = 64;
-  else if (strcmp(type, PIDX_DType.INT64_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT64_GA) == 0)
     *bits = 128;
-  else if (strcmp(type, PIDX_DType.INT64_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT64_RGB) == 0)
     *bits = 192;
-  else if (strcmp(type, PIDX_DType.INT64_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.INT64_RGBA) == 0)
     *bits = 256;
 
-  else if (strcmp(type, PIDX_DType.UINT64) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT64) == 0)
     *bits = 64;
-  else if (strcmp(type, PIDX_DType.UINT64_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT64_GA) == 0)
     *bits = 128;
-  else if (strcmp(type, PIDX_DType.UINT64_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT64_RGB) == 0)
     *bits = 192;
-  else if (strcmp(type, PIDX_DType.UINT64_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.UINT64_RGBA) == 0)
     *bits = 256;
 
-  else if (strcmp(type, PIDX_DType.FLOAT32) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT32) == 0)
     *bits = 32;
-  else if (strcmp(type, PIDX_DType.FLOAT32_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT32_GA) == 0)
     *bits = 64;
-  else if (strcmp(type, PIDX_DType.FLOAT32_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT32_RGB) == 0)
     *bits = 96;
-  else if (strcmp(type, PIDX_DType.FLOAT32_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT32_RGBA) == 0)
     *bits = 128;
-  else if (strcmp(type, PIDX_DType.FLOAT32_7STENCIL) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT32_7STENCIL) == 0)
     *bits = 224;
-  else if (strcmp(type, PIDX_DType.FLOAT32_9TENSOR) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT32_9TENSOR) == 0)
     *bits = 288;
 
-  else if (strcmp(type, PIDX_DType.FLOAT64) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT64) == 0)
     *bits = 64;
-  else if (strcmp(type, PIDX_DType.FLOAT64_GA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT64_GA) == 0)
     *bits = 128;
-  else if (strcmp(type, PIDX_DType.FLOAT64_RGB) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT64_RGB) == 0)
     *bits = 192;
-  else if (strcmp(type, PIDX_DType.FLOAT64_RGBA) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT64_RGBA) == 0)
     *bits = 256;
-  else if (strcmp(type, PIDX_DType.FLOAT64_7STENCIL) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT64_7STENCIL) == 0)
     *bits = 448;
-  else if (strcmp(type, PIDX_DType.FLOAT64_9TENSOR) == 0)
+  else if (strcmp(full_typename, PIDX_DType.FLOAT64_9TENSOR) == 0)
     *bits = 576;
   else
     *bits = 0;
@@ -207,112 +215,118 @@ PIDX_return_code PIDX_default_bits_per_datatype(PIDX_data_type type, int* bits)
 
 PIDX_return_code PIDX_values_per_datatype(PIDX_data_type type, int* values, int* bits)
 {
-    if (strcmp(type, PIDX_DType.INT8) == 0)
+    char full_typename[64];
+    strncpy(full_typename, type, 64);
+    if(!isdigit(full_typename[0])){
+      sprintf(full_typename, "1*%s", type);
+    }
+
+    if (strcmp(full_typename, PIDX_DType.INT8) == 0)
     {
       *bits = 8;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.INT8_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT8_GA) == 0)
     {
       *bits = 8;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.INT8_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT8_RGB) == 0)
     {
       *bits = 8;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.INT8_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT8_RGBA) == 0)
     {
       *bits = 8;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.UINT8) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT8) == 0)
     {
       *bits = 8;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.UINT8_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT8_GA) == 0)
     {
       *bits = 8;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.UINT8_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT8_RGB) == 0)
     {
       *bits = 8;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.UINT8_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT8_RGBA) == 0)
     {
       *bits = 8;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.INT16) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT16) == 0)
     {
       *bits = 16;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.INT16_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT16_GA) == 0)
     {
       *bits = 16;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.INT16_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT16_RGB) == 0)
     {
       *bits = 16;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.INT16_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT16_RGBA) == 0)
     {
       *bits = 16;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.UINT16) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT16) == 0)
     {
       *bits = 16;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.UINT16_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT16_GA) == 0)
     {
       *bits = 16;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.UINT16_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT16_RGB) == 0)
     {
       *bits = 16;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.UINT16_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT16_RGBA) == 0)
     {
       *bits = 16;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.INT32) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT32) == 0)
     {
       *bits = 32;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.INT32_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT32_GA) == 0)
     {
       *bits = 32;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.INT32_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT32_RGB) == 0)
     {
       *bits = 32;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.INT32_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT32_RGBA) == 0)
     {
       *bits = 32;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.UINT32) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT32) == 0)
     {
       *bits = 32;
       *values = 1;
@@ -322,116 +336,116 @@ PIDX_return_code PIDX_values_per_datatype(PIDX_data_type type, int* values, int*
       *bits = 32;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.UINT32_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT32_RGB) == 0)
     {
       *bits = 32;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.UINT32_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT32_RGBA) == 0)
     {
       *bits = 32;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.INT64) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT64) == 0)
     {
       *bits = 64;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.INT64_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT64_GA) == 0)
     {
       *bits = 64;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.INT64_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT64_RGB) == 0)
     {
       *bits = 64;
       *values = 3;
     }
-    else if (strcmp(type, PIDX_DType.INT64_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.INT64_RGBA) == 0)
     {
       *bits = 64;
       *values = 4;
     }
 
-    else if (strcmp(type, PIDX_DType.UINT64) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT64) == 0)
     {
       *bits = 64;
       *values = 1;
     }
-    else if (strcmp(type, PIDX_DType.UINT64_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT64_GA) == 0)
     {
       *bits = 64;
       *values = 2;
     }
-    else if (strcmp(type, PIDX_DType.UINT64_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT64_RGB) == 0)
     {
       *values = 3;
       *bits = 64;
     }
-    else if (strcmp(type, PIDX_DType.UINT64_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.UINT64_RGBA) == 0)
     {
       *values = 4;
       *bits = 64;
     }
 
-    else if (strcmp(type, PIDX_DType.FLOAT32) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT32) == 0)
     {
       *values = 1;
       *bits = 32;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT32_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT32_GA) == 0)
     {
       *values = 2;
       *bits = 32;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT32_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT32_RGB) == 0)
     {
       *values = 3;
       *bits = 32;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT32_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT32_RGBA) == 0)
     {
       *values = 4;
       *bits = 32;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT32_7STENCIL) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT32_7STENCIL) == 0)
     {
       *values = 7;
       *bits = 32;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT32_9TENSOR) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT32_9TENSOR) == 0)
     {
       *values = 9;
       *bits = 32;
     }
 
-    else if (strcmp(type, PIDX_DType.FLOAT64) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT64) == 0)
     {
       *values = 1;
       *bits = 64;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT64_GA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT64_GA) == 0)
     {
       *values = 2;
       *bits = 64;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT64_RGB) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT64_RGB) == 0)
     {
       *values = 3;
       *bits = 64;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT64_RGBA) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT64_RGBA) == 0)
     {
       *values = 4;
       *bits = 64;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT64_7STENCIL) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT64_7STENCIL) == 0)
     {
       *values = 7;
       *bits = 64;
     }
-    else if (strcmp(type, PIDX_DType.FLOAT64_9TENSOR) == 0)
+    else if (strcmp(full_typename, PIDX_DType.FLOAT64_9TENSOR) == 0)
     {
       *values = 9;
       *bits = 64;

--- a/pidx/PIDX_debug.c
+++ b/pidx/PIDX_debug.c
@@ -182,11 +182,11 @@ static PIDX_return_code dump_debug_data_init(PIDX_file file)
 {
   if (file->idx_dbg->debug_file_output_state == PIDX_META_DATA_DUMP_ONLY || file->idx_dbg->debug_file_output_state == PIDX_NO_IO_AND_META_DATA_DUMP)
   {
-    char local_file_name[1024];
+    char local_file_name[PIDX_FILE_PATH_LENGTH];
 
     if (file->idx_c->simulation_rank == 0)
     {
-      char mkdir_line2[1024];
+      char mkdir_line2[PIDX_FILE_PATH_LENGTH];
       sprintf(mkdir_line2, "mkdir -p %s", local_debug_file_output_state_dir_name);
       system(mkdir_line2);
     }

--- a/pidx/PIDX_define.h
+++ b/pidx/PIDX_define.h
@@ -129,6 +129,7 @@ enum PIDX_endian_type{
 #define PIDX_default_bits_per_block              15
 #define PIDX_default_blocks_per_file             256
 
+#define PIDX_FILE_PATH_LENGTH                    1024
 
 /// Create the file if it does not exist.
 #define PIDX_MODE_CREATE              1

--- a/pidx/PIDX_file_create.c
+++ b/pidx/PIDX_file_create.c
@@ -60,7 +60,7 @@ PIDX_return_code PIDX_file_create(const char* filename, PIDX_flags flags, PIDX_a
 
   uint64_t i = 0;
   int ret;
-  char file_name_skeleton[1024];
+  char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
 
   if (strncmp(".idx", &filename[strlen(filename) - 4], 4) != 0 && !filename){
     fprintf(stderr,"[%s] [%d]\n", __FILE__, __LINE__);

--- a/pidx/PIDX_file_create.c
+++ b/pidx/PIDX_file_create.c
@@ -166,6 +166,7 @@ PIDX_return_code PIDX_file_create(const char* filename, PIDX_flags flags, PIDX_a
 
   sprintf((*file)->idx->filename, "%s.idx", file_name_skeleton);
   sprintf((*file)->idx->filename_partition, "%s_0.idx", file_name_skeleton);
+  sprintf((*file)->idx->filename_time_template, "time%%09d/");
 
   (*file)->idx->blocks_per_file = PIDX_default_blocks_per_file;
 

--- a/pidx/PIDX_file_open.c
+++ b/pidx/PIDX_file_open.c
@@ -44,7 +44,7 @@
 PIDX_return_code PIDX_file_open(const char* filename, PIDX_flags flags, PIDX_access access_type, PIDX_point dims, PIDX_file* file)
 {
   int i;
-  char file_name_skeleton[1024];
+  char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
 
   if (strncmp(".idx", &filename[strlen(filename) - 4], 4) != 0 && !filename)
     return PIDX_err_name;
@@ -194,7 +194,6 @@ PIDX_return_code PIDX_file_open(const char* filename, PIDX_flags flags, PIDX_acc
   MPI_Bcast(&((*file)->idx->blocks_per_file), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast(&((*file)->idx->bits_per_block), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast(&((*file)->idx->variable_count), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
-  MPI_Bcast(&((*file)->idx->variable_count), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast((*file)->idx->bitSequence, 512, MPI_CHAR, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast((*file)->idx->partition_count, PIDX_MAX_DIMENSIONS, MPI_INT, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast((*file)->idx->partition_size, PIDX_MAX_DIMENSIONS, MPI_INT, 0, (*file)->idx_c->simulation_comm);
@@ -203,6 +202,13 @@ PIDX_return_code PIDX_file_open(const char* filename, PIDX_flags flags, PIDX_acc
   MPI_Bcast(&((*file)->idx->compression_type), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast(&((*file)->idx->io_type), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
   MPI_Bcast(&((*file)->fs_block_size), 1, MPI_INT, 0, (*file)->idx_c->simulation_comm);
+
+  // broadcast all filename templates
+  MPI_Bcast((*file)->idx->filename_template, PIDX_FILE_PATH_LENGTH, MPI_CHAR, 0, (*file)->idx_c->simulation_comm);
+  MPI_Bcast(&((*file)->idx->filename_partition), PIDX_FILE_PATH_LENGTH, MPI_CHAR, 0, (*file)->idx_c->simulation_comm);
+  MPI_Bcast(&((*file)->idx->filename_template_partition), PIDX_FILE_PATH_LENGTH, MPI_CHAR, 0, (*file)->idx_c->simulation_comm);
+  MPI_Bcast((*file)->idx->filename_time_template, PIDX_FILE_PATH_LENGTH, MPI_CHAR, 0, (*file)->idx_c->simulation_comm);
+
   
   //printf("reading version %d\n",(*file)->idx->metadata_version);
   if ((*file)->idx->io_type == PIDX_IDX_IO)
@@ -298,7 +304,7 @@ PIDX_return_code PIDX_file_open(const char* filename, PIDX_flags flags, PIDX_acc
 PIDX_return_code PIDX_serial_file_open(const char* filename, PIDX_flags flags, PIDX_point dims, PIDX_file* file)
 {
   int i;
-  char file_name_skeleton[1024];
+  char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
   
   if (strncmp(".idx", &filename[strlen(filename) - 4], 4) != 0 && !filename)
     return PIDX_err_name;

--- a/pidx/core/PIDX_generic_rst/PIDX_generic_rst_io.c
+++ b/pidx/core/PIDX_generic_rst/PIDX_generic_rst_io.c
@@ -179,7 +179,9 @@ PIDX_return_code PIDX_generic_rst_buf_read_and_aggregate(PIDX_generic_rst_id gen
   memset(data_set_path, 0, sizeof(*data_set_path) * PATH_MAX);
 
   strncpy(directory_path, generic_rst_id->idx->filename, strlen(generic_rst_id->idx->filename) - 4);
-  sprintf(data_set_path, "%s/time%09d/", directory_path, generic_rst_id->idx->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s", generic_rst_id->idx->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, generic_rst_id->idx->current_time_step);
 
   for (v = generic_rst_id->first_index; v <= generic_rst_id->last_index; ++v)
   {
@@ -282,7 +284,9 @@ PIDX_return_code PIDX_generic_rst_buf_aggregated_write(PIDX_generic_rst_id gener
   file_name = malloc(PATH_MAX * sizeof(*file_name));
   memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-  sprintf(file_name, "%s/time%09d/%d_0", directory_path, generic_rst_id->idx->current_time_step, generic_rst_id->idx_c->grank);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_0", generic_rst_id->idx->filename_time_template);
+  sprintf(file_name, time_template, directory_path, generic_rst_id->idx->current_time_step, generic_rst_id->idx_c->grank);
   int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
 
   int v_start = 0;

--- a/pidx/core/PIDX_generic_rst/PIDX_generic_rst_io.c
+++ b/pidx/core/PIDX_generic_rst/PIDX_generic_rst_io.c
@@ -68,7 +68,9 @@ PIDX_return_code PIDX_generic_rst_buf_aggregate_and_write(PIDX_generic_rst_id ge
   file_name = malloc(PATH_MAX * sizeof(*file_name));
   memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-  sprintf(file_name, "%s/time%09d/%d_0", directory_path, generic_rst_id->idx->current_time_step, generic_rst_id->idx_c->grank);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_0", file->idx->filename_time_template);
+  sprintf(file_name, time_template, directory_path, generic_rst_id->idx->current_time_step, generic_rst_id->idx_c->grank);
   int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
 
   int v_start = 0, v_end = 0;

--- a/pidx/core/PIDX_generic_rst/PIDX_generic_rst_raw_read.c
+++ b/pidx/core/PIDX_generic_rst/PIDX_generic_rst_raw_read.c
@@ -167,7 +167,9 @@ PIDX_return_code PIDX_generic_rst_forced_raw_read(PIDX_generic_rst_id rst_id)
   memset(data_set_path, 0, sizeof(*data_set_path) * PATH_MAX);
 
   strncpy(directory_path, rst_id->idx->filename, strlen(rst_id->idx->filename) - 4);
-  sprintf(data_set_path, "%s/time%09d/", directory_path, rst_id->idx->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s", rst_id->idx->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, rst_id->idx->current_time_step);
 
 
   int pc1 = 0;
@@ -314,9 +316,12 @@ PIDX_return_code PIDX_generic_rst_forced_raw_read(PIDX_generic_rst_id rst_id)
       }
     }
 
+    char time_template[512];
+    sprintf(time_template, "%%s/%s/%%d_%%d", rst_id->idx->filename_time_template);
+
     for (i = 0; i < patch_count; i++)
     {
-      sprintf(file_name, "%s/time%09d/%d_%d", directory_path, rst_id->idx->current_time_step, patch_grp->source_patch_rank[i], source_patch_id[i]);
+      sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, patch_grp->source_patch_rank[i], source_patch_id[i]);
       int fpx = open(file_name, O_RDONLY);
 
       pc_index = patch_grp->source_patch_rank[i] * (max_patch_count * temp_max_dim + 1);

--- a/pidx/core/PIDX_header/PIDX_header_io.c
+++ b/pidx/core/PIDX_header/PIDX_header_io.c
@@ -184,7 +184,9 @@ int PIDX_header_io_raw_dir_create(PIDX_header_io_id header_io_id, char* file_nam
   memset(data_set_path, 0, sizeof(*data_set_path) * PATH_MAX);
 
   strncpy(directory_path, file_name, strlen(file_name) - 4);
-  sprintf(data_set_path, "%s/time%09d/", directory_path, header_io_id->idx->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s", header_io_id->idx->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, header_io_id->idx->current_time_step);
   free(directory_path);
 
   if (header_io_id->idx_c->partition_rank == 0)

--- a/pidx/core/PIDX_header/PIDX_header_io.c
+++ b/pidx/core/PIDX_header/PIDX_header_io.c
@@ -282,8 +282,8 @@ PIDX_return_code PIDX_header_io_global_idx_write (PIDX_header_io_id header_io, c
 {
   int N;
   FILE* idx_file_p;
-  char dirname[1024], basename[1024];
-  char file_temp[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
+  char file_temp[PIDX_FILE_PATH_LENGTH];
 
   int nbits_blocknumber = (header_io->idx->maxh - header_io->idx->bits_per_block - 1);
   VisusSplitFilename(data_set_path, dirname, basename);
@@ -450,8 +450,8 @@ PIDX_return_code PIDX_header_io_partition_idx_write (PIDX_header_io_id header_io
 {
   int l = 0, N;
   FILE* idx_file_p;
-  char dirname[1024], basename[1024];
-  char file_temp[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
+  char file_temp[PIDX_FILE_PATH_LENGTH];
 
   int nbits_blocknumber = (header_io->idx->maxh - header_io->idx->bits_per_block - 1);
   VisusSplitFilename(data_set_path, dirname, basename);
@@ -581,8 +581,8 @@ PIDX_return_code PIDX_header_io_raw_idx_write (PIDX_header_io_id header_io, char
 {
   int l = 0, N;
   FILE* idx_file_p;
-  char dirname[1024], basename[1024];
-  char file_temp[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
+  char file_temp[PIDX_FILE_PATH_LENGTH];
 
   int nbits_blocknumber = (header_io->idx->maxh - header_io->idx->bits_per_block - 1);
   VisusSplitFilename(data_set_path, dirname, basename);

--- a/pidx/core/PIDX_idx_rst/PIDX_idx_rst_io.c
+++ b/pidx/core/PIDX_idx_rst/PIDX_idx_rst_io.c
@@ -72,7 +72,9 @@ PIDX_return_code PIDX_idx_rst_buf_aggregated_write(PIDX_idx_rst_id rst_id)
   file_name = malloc(PATH_MAX * sizeof(*file_name));
   memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-  sprintf(file_name, "%s/time%09d/%d_0", directory_path, rst_id->idx_metadata->current_time_step, rst_id->idx_c->simulation_rank);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_0", rst_id->idx_metadata->filename_time_template);
+  sprintf(file_name, time_template, directory_path, rst_id->idx_metadata->current_time_step, rst_id->idx_c->simulation_rank);
   int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
 
   int v = 0;

--- a/pidx/core/PIDX_idx_rst/PIDX_idx_rst_raw_read.c
+++ b/pidx/core/PIDX_idx_rst/PIDX_idx_rst_raw_read.c
@@ -166,7 +166,9 @@ PIDX_return_code PIDX_idx_rst_forced_raw_read(PIDX_idx_rst_id rst_id)
   memset(data_set_path, 0, sizeof(*data_set_path) * PATH_MAX);
 
   strncpy(directory_path, rst_id->idx_metadata->filename, strlen(rst_id->idx_metadata->filename) - 4);
-  sprintf(data_set_path, "%s/time%09d/", directory_path, rst_id->idx_metadata->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s", rst_id->idx_metadata->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, rst_id->idx_metadata->current_time_step);
 
 
   int pc1 = 0;
@@ -313,9 +315,12 @@ PIDX_return_code PIDX_idx_rst_forced_raw_read(PIDX_idx_rst_id rst_id)
       }
     }
 
+    char time_template[512];
+    sprintf(time_template, "%%s/%s/%%d_%%d", rst_id->idx_metadata->filename_time_template);
+
     for (i = 0; i < patch_count; i++)
     {
-      sprintf(file_name, "%s/time%09d/%d_%d", directory_path, rst_id->idx_metadata->current_time_step, patch_grp->source_patch[i].rank, source_patch_id[i]);
+      sprintf(file_name, time_template, directory_path, rst_id->idx_metadata->current_time_step, patch_grp->source_patch[i].rank, source_patch_id[i]);
       int fpx = open(file_name, O_RDONLY);
 
       pc_index = patch_grp->source_patch[i].rank * (max_patch_count * temp_max_dim + 1);

--- a/pidx/core/PIDX_particles_rst/PIDX_particles_rst_io.c
+++ b/pidx/core/PIDX_particles_rst/PIDX_particles_rst_io.c
@@ -73,7 +73,9 @@ PIDX_return_code PIDX_particles_rst_buf_aggregated_write(PIDX_particles_rst_id r
   file_name = malloc(PATH_MAX * sizeof(*file_name));
   memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-  sprintf(file_name, "%s/time%09d/%d_0", directory_path, rst_id->idx_metadata->current_time_step, rst_id->idx_c->simulation_rank);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_0", rst_id->idx_metadata->filename_time_template);
+  sprintf(file_name, time_template, directory_path, rst_id->idx_metadata->current_time_step, rst_id->idx_c->simulation_rank);
   int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
 
   double particle_reshuffling_time = 0, temp_time;

--- a/pidx/core/PIDX_particles_rst/PIDX_particles_rst_meta_data.c
+++ b/pidx/core/PIDX_particles_rst/PIDX_particles_rst_meta_data.c
@@ -602,7 +602,9 @@ PIDX_return_code PIDX_particles_rst_meta_data_write(PIDX_particles_rst_id rst_id
   memset(directory_path, 0, sizeof(*directory_path) * PATH_MAX);
   strncpy(directory_path, rst_id->idx_metadata->filename, strlen(rst_id->idx_metadata->filename) - 4);
 
-  sprintf(file_path, "%s/time%09d/OFFSET_SIZE", directory_path, rst_id->idx_metadata->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/OFFSET_SIZE", rst_id->idx_metadata->filename_time_template);
+  sprintf(file_path, time_template, directory_path, rst_id->idx_metadata->current_time_step);
   free(directory_path);
   if (rst_id->idx_c->simulation_rank == 1 || rst_id->idx_c->simulation_nprocs == 1)
   {

--- a/pidx/core/PIDX_raw_rst/PIDX_raw_rst_io.c
+++ b/pidx/core/PIDX_raw_rst/PIDX_raw_rst_io.c
@@ -64,6 +64,9 @@ PIDX_return_code PIDX_raw_rst_buf_aggregate_and_write(PIDX_raw_rst_id rst_id)
   memset(directory_path, 0, sizeof(*directory_path) * PATH_MAX);
   strncpy(directory_path, rst_id->idx->filename, strlen(rst_id->idx->filename) - 4);
 
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_%%d", rst_id->idx->filename_time_template);
+
   int g = 0;
   PIDX_variable var0 = rst_id->idx->variable[rst_id->first_index];
   for (g = 0; g < var0->raw_io_restructured_super_patch_count; ++g)
@@ -74,7 +77,7 @@ PIDX_return_code PIDX_raw_rst_buf_aggregate_and_write(PIDX_raw_rst_id rst_id)
     file_name = malloc(PATH_MAX * sizeof(*file_name));
     memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-    sprintf(file_name, "%s/time%09d/%d_%d", directory_path, rst_id->idx->current_time_step, rst_id->idx_c->simulation_rank, g);
+    sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, rst_id->idx_c->simulation_rank, g);
     int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
 
     int v_start = 0, v_end = 0;
@@ -177,6 +180,9 @@ PIDX_return_code PIDX_raw_rst_buf_read_and_aggregate(PIDX_raw_rst_id rst_id)
   strncpy(directory_path, rst_id->idx->filename, strlen(rst_id->idx->filename) - 4);
   sprintf(data_set_path, "%s/time%09d/", directory_path, rst_id->idx->current_time_step);
 
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_%%d", rst_id->idx->filename_time_template);
+
   for (v = rst_id->first_index; v <= rst_id->last_index; ++v)
   {
     PIDX_variable var = rst_id->idx->variable[v];
@@ -209,7 +215,7 @@ PIDX_return_code PIDX_raw_rst_buf_read_and_aggregate(PIDX_raw_rst_id rst_id)
       file_name = malloc(PATH_MAX * sizeof(*file_name));
       memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-      sprintf(file_name, "%s/time%09d/%d_%d", directory_path, rst_id->idx->current_time_step, rst_id->idx_c->simulation_rank, g);
+      sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, rst_id->idx_c->simulation_rank, g);
 
       MPI_Status status;
       int ret = 0;
@@ -324,6 +330,9 @@ PIDX_return_code PIDX_raw_rst_buf_aggregated_read(PIDX_raw_rst_id rst_id)
   memset(directory_path, 0, sizeof(*directory_path) * PATH_MAX);
   strncpy(directory_path, rst_id->idx->filename, strlen(rst_id->idx->filename) - 4);
 
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_%%d", rst_id->idx->filename_time_template);
+
   PIDX_variable var0 = rst_id->idx->variable[rst_id->first_index];
   for (g = 0; g < var0->raw_io_restructured_super_patch_count; ++g)
   {
@@ -332,7 +341,7 @@ PIDX_return_code PIDX_raw_rst_buf_aggregated_read(PIDX_raw_rst_id rst_id)
     file_name = malloc(PATH_MAX * sizeof(*file_name));
     memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
-    sprintf(file_name, "%s/time%09d/%d_%d", directory_path, rst_id->idx->current_time_step, rst_id->idx_c->simulation_rank, g);
+    sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, rst_id->idx_c->simulation_rank, g);
     int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
 
     int v_start = 0;

--- a/pidx/core/PIDX_raw_rst/PIDX_raw_rst_raw_read.c
+++ b/pidx/core/PIDX_raw_rst/PIDX_raw_rst_raw_read.c
@@ -177,7 +177,9 @@ PIDX_return_code PIDX_raw_rst_forced_raw_read(PIDX_raw_rst_id rst_id)
   memset(data_set_path, 0, sizeof(*data_set_path) * PATH_MAX);
 
   strncpy(directory_path, rst_id->idx->filename, strlen(rst_id->idx->filename) - 4);
-  sprintf(data_set_path, "%s/time%09d/", directory_path, rst_id->idx->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s", rst_id->idx->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, rst_id->idx->current_time_step);
 
   for (int pc1 = 0; pc1 < rst_id->idx->variable[svi]->sim_patch_count; pc1++)
   {
@@ -307,6 +309,9 @@ PIDX_return_code PIDX_raw_rst_forced_raw_read(PIDX_raw_rst_id rst_id)
     temp_patch_buffer2 = malloc(sizeof(*temp_patch_buffer2) * (evi - svi + 1));
     memset(temp_patch_buffer2, 0, sizeof(*temp_patch_buffer2) * (evi - svi + 1));
 
+    char time_template[512];
+    sprintf(time_template, "%%s/%s/%%d_%%d", rst_id->idx->filename_time_template);
+
     int other_offset = 0;
     for (int start_index = svi; start_index <= evi; start_index = start_index + 1)
     {
@@ -327,7 +332,7 @@ PIDX_return_code PIDX_raw_rst_forced_raw_read(PIDX_raw_rst_id rst_id)
         temp_patch_buffer2[index] = malloc((uint64_t) sizeof(*(temp_patch_buffer2[index])) * total_sample_count * var->bpv/8 * var->vps);
         memset(temp_patch_buffer2[index], 0, (uint64_t) sizeof(*(temp_patch_buffer2[index])) * total_sample_count * var->bpv/8 * var->vps);
 
-        sprintf(file_name, "%s/time%09d/%d_%d", directory_path, rst_id->idx->current_time_step, patch_grp->source_patch[i].rank, source_patch_id[i]);
+        sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, patch_grp->source_patch[i].rank, source_patch_id[i]);
 
         int fpx = open(file_name, O_RDONLY);
         other_offset = 0;

--- a/pidx/data_handle/PIDX_idx_file_structs.h
+++ b/pidx/data_handle/PIDX_idx_file_structs.h
@@ -65,11 +65,11 @@ struct idx_file_struct
   Agg_buffer **agg_buffer;                          /// aggregation related struct
 
 
-  char filename[1024];                              /// The .idx file path
-  char filename_template[1024];                     /// Filename template use to resolve the path of the .idx file and binaries
-  char filename_partition[1024];                    /// The .idx file for partitioned I/O
-  char filename_template_partition[1024];           /// Filename template for the binary files
-  char filename_time_template[1024];                /// Filename template used to resolve the path of time folders
+  char filename[PIDX_FILE_PATH_LENGTH];             /// The .idx file path
+  char filename_template[PIDX_FILE_PATH_LENGTH];    /// Filename template use to resolve the path of the .idx file and binaries
+  char filename_partition[PIDX_FILE_PATH_LENGTH];   /// The .idx file for partitioned I/O
+  char filename_template_partition[PIDX_FILE_PATH_LENGTH];/// Filename template for the binary files
+  char filename_time_template[PIDX_FILE_PATH_LENGTH];/// Filename template used to resolve the path of time folders
 
   int bits_per_block;                               /// Number of bits per block
   uint64_t samples_per_block;                       /// Number of samples in a block 2^bits_per_block

--- a/pidx/data_handle/PIDX_idx_file_structs.h
+++ b/pidx/data_handle/PIDX_idx_file_structs.h
@@ -65,11 +65,11 @@ struct idx_file_struct
   Agg_buffer **agg_buffer;                          /// aggregation related struct
 
 
-  char filename[1024];                              /// The idx file path
-  char filename_template[1024];
-  char filename_partition[1024];
-  char filename_template_partition[1024];
-  char filename_time_template[1024];
+  char filename[1024];                              /// The .idx file path
+  char filename_template[1024];                     /// Filename template use to resolve the path of the .idx file and binaries
+  char filename_partition[1024];                    /// The .idx file for partitioned I/O
+  char filename_template_partition[1024];           /// Filename template for the binary files
+  char filename_time_template[1024];                /// Filename template used to resolve the path of time folders
 
   int bits_per_block;                               /// Number of bits per block
   uint64_t samples_per_block;                       /// Number of samples in a block 2^bits_per_block

--- a/pidx/data_handle/PIDX_idx_file_structs.h
+++ b/pidx/data_handle/PIDX_idx_file_structs.h
@@ -69,6 +69,7 @@ struct idx_file_struct
   char filename_template[1024];
   char filename_partition[1024];
   char filename_template_partition[1024];
+  char filename_time_template[1024];
 
   int bits_per_block;                               /// Number of bits per block
   uint64_t samples_per_block;                       /// Number of samples in a block 2^bits_per_block

--- a/pidx/data_handle/PIDX_variable_structs.h
+++ b/pidx/data_handle/PIDX_variable_structs.h
@@ -46,7 +46,7 @@
 struct PIDX_variable_struct
 {
   // General Info
-  char var_name[1024];                                       ///< Variable name
+  char var_name[PIDX_FILE_PATH_LENGTH];                                       ///< Variable name
   int vps;                                                   ///< values per sample, Vector(3), scalar(1), or n
   int bpv;                                                   ///< Number of bits each need
   PIDX_data_type type_name;                                  ///< Name of the type uint8, bob
@@ -55,7 +55,7 @@ struct PIDX_variable_struct
 
   // buffer (before, after HZ encoding phase)
   int sim_patch_count;                                       ///< Number of patches/blocks that the simulation feeds to PIDX (application layout)
-  PIDX_patch sim_patch[1024];                                ///< Pointer to the patches
+  PIDX_patch sim_patch[PIDX_FILE_PATH_LENGTH];                                ///< Pointer to the patches
 
 
   // buffer after restructuring

--- a/pidx/io/idx/headers.c
+++ b/pidx/io/idx/headers.c
@@ -47,7 +47,7 @@ static PIDX_return_code write_idx_headers_layout(PIDX_io file, int start_var_ind
 PIDX_return_code write_global_idx(PIDX_io file, int start_var_index, int end_var_index, int mode)
 {
   // populate the filename template
-  generate_file_name_template(file->idx->maxh, file->idx->bits_per_block, file->idx->filename, file->idx->current_time_step, file->idx->filename_template);
+  generate_file_name_template(file->idx->maxh, file->idx->bits_per_block, file->idx->filename, file->idx->filename_time_template, file->idx->current_time_step, file->idx->filename_template);
 
   if (mode != PIDX_WRITE)
     return PIDX_success;
@@ -80,7 +80,7 @@ PIDX_return_code write_headers(PIDX_io file, int start_var_index, int end_var_in
   if (file->idx->io_type == PIDX_IDX_IO)
     strcpy(file->idx->filename_partition,file->idx->filename);
   
-  generate_file_name_template(file->idx->maxh, file->idx->bits_per_block, file->idx->filename_partition, file->idx->current_time_step, file->idx->filename_template_partition);
+  generate_file_name_template(file->idx->maxh, file->idx->bits_per_block, file->idx->filename_partition, file->idx->filename_time_template, file->idx->current_time_step, file->idx->filename_template_partition);
 
   //fprintf(stderr, "(maxh %d) FN %s FNT %s\n",file->idx->maxh, file->idx->filename_partition, file->idx->filename_template_partition);
 

--- a/pidx/io/idx/local_partition/local_partition_generic_read.c
+++ b/pidx/io/idx/local_partition/local_partition_generic_read.c
@@ -80,7 +80,9 @@ PIDX_return_code PIDX_local_partition_idx_generic_read(PIDX_io file, int svi, in
         // populate the local partition template using the current time step index
         char dirname[1024], basename[1024];
         VisusSplitFilename(file->idx->filename_template_partition, dirname, basename);
-        sprintf(file->idx->filename_template_partition, "%s/time%09d/%s", dirname, file->idx->current_time_step, basename );
+        char time_template[512];
+        sprintf(time_template, "%%s/%s/%%s", file->idx->filename_time_template);
+        sprintf(file->idx->filename_template_partition, time_template, dirname, file->idx->current_time_step, basename );
 
         // Checking if the simulation patch intersects with the partition
         int d = 0, check_bit = 0;

--- a/pidx/io/idx/local_partition/local_partition_generic_read.c
+++ b/pidx/io/idx/local_partition/local_partition_generic_read.c
@@ -78,7 +78,7 @@ PIDX_return_code PIDX_local_partition_idx_generic_read(PIDX_io file, int svi, in
             continue;
 
         // populate the local partition template using the current time step index
-        char dirname[1024], basename[1024];
+        char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
         VisusSplitFilename(file->idx->filename_template_partition, dirname, basename);
         char time_template[512];
         sprintf(time_template, "%%s/%s/%%s", file->idx->filename_time_template);
@@ -219,7 +219,7 @@ static PIDX_return_code parse_local_partition_idx_file(PIDX_io file, int partiti
 {
   // Parse the partition idx file to get partition specific meta data
 
-  char file_name_skeleton[1024];
+  char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
   strncpy(file_name_skeleton, file->idx->filename, strlen(file->idx->filename) - 4);
   file_name_skeleton[strlen(file->idx->filename) - 4] = '\0';
   sprintf(file->idx->filename_partition, "%s_%d.idx", file_name_skeleton, partition_index);

--- a/pidx/io/idx/partition.c
+++ b/pidx/io/idx/partition.c
@@ -239,7 +239,7 @@ static PIDX_return_code partition_setup(PIDX_io file, int svi)
 
   free(colors);
 
-  char file_name_skeleton[1024];
+  char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
   strncpy(file_name_skeleton, file->idx->filename, strlen(file->idx->filename) - 4);
   file_name_skeleton[strlen(file->idx->filename) - 4] = '\0';
   sprintf(file->idx->filename_partition, "%s_%d.idx", file_name_skeleton, file->idx_c->color);
@@ -345,8 +345,8 @@ static PIDX_return_code create_midx(PIDX_io file, int svi)
 {
 
   int N;
-  char dirname[1024], basename[1024];
-  char file_temp[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
+  char file_temp[PIDX_FILE_PATH_LENGTH];
 
   int nbits_blocknumber = (file->idx->maxh - file->idx->bits_per_block - 1);
   VisusSplitFilename(file->idx->filename, dirname, basename);

--- a/pidx/io/particle/particle_file_per_process_io.c
+++ b/pidx/io/particle/particle_file_per_process_io.c
@@ -68,13 +68,16 @@ PIDX_return_code PIDX_particle_file_per_process_write(PIDX_io file, int svi, int
   memset(directory_path, 0, sizeof(*directory_path) * PATH_MAX);
   strncpy(directory_path, file->idx->filename, strlen(file->idx->filename) - 4);
 
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/%%d_%%d", file->idx->filename_time_template);
+
   uint64_t local_pcount = 0;
   PIDX_variable var0 = file->idx->variable[svi];
   for (int p = 0; p < var0->sim_patch_count; p++)
   {
     char file_name[PATH_MAX];
     memset(file_name, 0, PATH_MAX * sizeof(*file_name));
-    sprintf(file_name, "%s/time%09d/%d_%d", directory_path, file->idx->current_time_step, file->idx_c->simulation_rank, p);
+    sprintf(file_name, time_template, directory_path, file->idx->current_time_step, file->idx_c->simulation_rank, p);
 
     int fp = open(file_name, O_CREAT | O_WRONLY, 0664);
     if (fp < 0)
@@ -267,7 +270,10 @@ static PIDX_return_code PIDX_meta_data_write(PIDX_io file, int svi)
   memset(directory_path, 0, sizeof(*directory_path) * PATH_MAX);
   strncpy(directory_path, file->idx->filename, strlen(file->idx->filename) - 4);
 
-  sprintf(file_path, "%s/time%09d/OFFSET_SIZE", directory_path, file->idx->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/OFFSET_SIZE", file->idx->filename_time_template);
+
+  sprintf(file_path, time_template, directory_path, file->idx->current_time_step);
   free(directory_path);
   if (file->idx_c->simulation_rank == 1 || file->idx_c->simulation_nprocs == 1)
   {

--- a/pidx/io/particle/particle_vis_read.c
+++ b/pidx/io/particle/particle_vis_read.c
@@ -54,7 +54,9 @@ PIDX_return_code PIDX_particle_vis_read(PIDX_io file, int svi, int evi)
   memset(idx_directory_path, 0, sizeof(*idx_directory_path) * PATH_MAX);
   strncpy(idx_directory_path, file->idx->filename, strlen(file->idx->filename) - 4);
 
-  sprintf(size_path, "%s/time%09d/OFFSET_SIZE", idx_directory_path, file->idx->current_time_step);
+  char time_template[512];
+  sprintf(time_template, "%%s/%s/OFFSET_SIZE", file->idx->filename_time_template);
+  sprintf(size_path, time_template, idx_directory_path, file->idx->current_time_step);
   free(idx_directory_path);
 
   double number_cores = 0;
@@ -140,6 +142,9 @@ PIDX_return_code PIDX_particle_vis_read(PIDX_io file, int svi, int evi)
     // LOD read stuff: read only num particles until current resolution level
     uint64_t curr_res_pcount = file->idx->particle_res_base * int_pow(file->idx->particle_res_factor,  file->idx->current_resolution);
 
+    char time_template[512];
+    sprintf(time_template, "%%s/%s/%%d_%%d", file->idx->filename_time_template);
+
     int patch_count = 0;
     for (int n = 0; n < number_cores; n++)
     {
@@ -163,7 +168,7 @@ PIDX_return_code PIDX_particle_vis_read(PIDX_io file, int svi, int evi)
 
         if (intersectNDChunk(local_proc_patch, n_proc_patch))
         {
-          sprintf(file_name, "%s/time%09d/%d_%d", directory_path, file->idx->current_time_step, n, m);
+          sprintf(file_name, time_template, directory_path, file->idx->current_time_step, n, m);
           int fpx = open(file_name, O_RDONLY);
 
           // TODO WILL: For particles we need to rethink how we do this loop, we'll need to

--- a/pidx/metadata/PIDX_metadata_parse_v6_0.c
+++ b/pidx/metadata/PIDX_metadata_parse_v6_0.c
@@ -349,8 +349,15 @@ PIDX_return_code PIDX_metadata_parse_v6_0(FILE *fp, PIDX_file* file)
 
       if (pch != NULL)
         (*file)->idx->last_tstep = atoi(pch);
+      else
+        return PIDX_err_file;
 
+      pch = strtok(NULL, " ");
 
+      if (pch != NULL) {
+        strcpy((*file)->idx->filename_time_template, pch);
+        replace_str((*file)->idx->filename_time_template, "%","%%");
+      }
       else
         return PIDX_err_file;
     }

--- a/pidx/metadata/PIDX_metadata_parse_v6_1.c
+++ b/pidx/metadata/PIDX_metadata_parse_v6_1.c
@@ -382,8 +382,15 @@ PIDX_return_code PIDX_metadata_parse_v6_1(FILE *fp, PIDX_file* file)
 
       if (pch != NULL)
         (*file)->idx->last_tstep = atoi(pch);
+      else
+        return PIDX_err_file;
 
+      pch = strtok(NULL, " ");
 
+      if (pch != NULL) {
+        strcpy((*file)->idx->filename_time_template, pch);
+        replace_str((*file)->idx->filename_time_template, "%","%%");
+      }
       else
         return PIDX_err_file;
     }

--- a/pidx/metadata/PIDX_metadata_parse_v6_1.c
+++ b/pidx/metadata/PIDX_metadata_parse_v6_1.c
@@ -362,6 +362,9 @@ PIDX_return_code PIDX_metadata_parse_v6_1(FILE *fp, PIDX_file* file)
       if ( fgets(line, sizeof line, fp) == NULL)
         return PIDX_err_file;
       line[strcspn(line, "\r\n")] = 0;
+      // TODO handle filename_template
+//      strcpy((*file)->idx->filename_template, line);
+//      replace_str((*file)->idx->filename_template, "%","%%");
     }
 
     if (strcmp(line, "(time)") == 0)

--- a/pidx/utils/PIDX_file_name.c
+++ b/pidx/utils/PIDX_file_name.c
@@ -205,7 +205,7 @@ int generate_file_name(int blocks_per_file, char* filename_template, int file_nu
 
 
 /////////////////////////////////////////////////
-int generate_file_name_template(int maxh, int bits_per_block, char* filename, int current_time_step, char* filename_template)
+int generate_file_name_template(int maxh, int bits_per_block, char* filename, char* time_template, int current_time_step, char* filename_template)
 {
   int N;
   char dirname[1024], basename[1024];
@@ -219,8 +219,11 @@ int generate_file_name_template(int maxh, int bits_per_block, char* filename, in
   directory_path = malloc(sizeof(*directory_path) * 1024);
   memset(directory_path, 0, sizeof(*directory_path) * 1024);
 
-  strncpy(directory_path, filename, strlen(filename) - 4);  
-  sprintf(data_set_path, "%s/time%09d.idx", directory_path, current_time_step);
+  strncpy(directory_path, filename, strlen(filename) - 4);
+  char this_time_template[512];
+  sprintf(this_time_template, "%%s/%s.idx", time_template);
+
+  sprintf(data_set_path, this_time_template, directory_path, current_time_step);
   free(directory_path);
 
   nbits_blocknumber = (maxh - bits_per_block - 1);

--- a/pidx/utils/PIDX_file_name.c
+++ b/pidx/utils/PIDX_file_name.c
@@ -53,12 +53,12 @@ void mira_create_folder_name(char* bin_file, char* folder_name)
   
   //fprintf(stderr, "Name length = %d\n", (ch_dot - ch_slash));
   
-  char file_name[1024];
+  char file_name[PIDX_FILE_PATH_LENGTH];
   memset(file_name, 0, (ch_dot - ch_slash));
   strncpy(file_name, bin_file + (ch_slash - bin_file + 1), (ch_dot - ch_slash - 1));
   //fprintf(stderr, "File name = %s\n", file_name);
   
-  char bin_file_first_part[1024];
+  char bin_file_first_part[PIDX_FILE_PATH_LENGTH];
   strncpy(bin_file_first_part, bin_file, (ch_slash - bin_file));
   //fprintf(stderr, "File name copy %s\n", bin_file_first_part);
   
@@ -80,12 +80,12 @@ void adjust_file_name(char* bin_file, char* adjusted_name)
   
   //fprintf(stderr, "Name length = %d\n", (ch_dot - ch_slash));
   
-  char file_name[1024];
+  char file_name[PIDX_FILE_PATH_LENGTH];
   memset(file_name, 0, (ch_dot - ch_slash));
   strncpy(file_name, bin_file + (ch_slash - bin_file + 1), (ch_dot - ch_slash - 1));
   //fprintf(stderr, "File name = %s\n", file_name);
   
-  char bin_file_first_part[1024];
+  char bin_file_first_part[PIDX_FILE_PATH_LENGTH];
   strncpy(bin_file_first_part, bin_file, (ch_slash - bin_file));
   //fprintf(stderr, "File name copy %s\n", bin_file_first_part);
   
@@ -95,7 +95,7 @@ void adjust_file_name(char* bin_file, char* adjusted_name)
   return;
 }
 
-int generate_file_name(int blocks_per_file, char* filename_template, int file_number, char* filename, int maxlen) 
+int generate_file_name(int blocks_per_file, char* filename_template, int file_number, char* filename, int maxlen)
 {
   uint64_t address = 0;
   unsigned int segs[PIDX_MAX_TEMPLATE_DEPTH] = {0};
@@ -208,7 +208,7 @@ int generate_file_name(int blocks_per_file, char* filename_template, int file_nu
 int generate_file_name_template(int maxh, int bits_per_block, char* filename, char* time_template, int current_time_step, char* filename_template)
 {
   int N;
-  char dirname[1024], basename[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
   int nbits_blocknumber;
   char* directory_path;
   char* data_set_path;

--- a/pidx/utils/PIDX_file_name.h
+++ b/pidx/utils/PIDX_file_name.h
@@ -44,7 +44,7 @@
 
 int generate_file_name(int blocks_per_file, char* filename_template, int file_number, char* filename, int maxlen);
 
-int generate_file_name_template(int maxh, int bits_per_block, char* filename, int current_time_step, char* filename_template);
+int generate_file_name_template(int maxh, int bits_per_block, char* filename, char* time_template, int current_time_step, char* filename_template);
 
 void adjust_file_name(char* bin_file, char* adjusted_name);
 

--- a/pidx/utils/PIDX_utils.c
+++ b/pidx/utils/PIDX_utils.c
@@ -1294,7 +1294,7 @@ PIDX_return_code PIDX_get_datatype_details(PIDX_data_type type, int* values, int
 
 char *replace_str(char *str, char *orig, char *rep)
 {
-  static char buffer[1024];
+  static char buffer[PIDX_FILE_PATH_LENGTH];
   char *p;
 
   if(!(p = strstr(str, orig)))  // Is 'orig' even in 'str'?

--- a/pidx/utils/PIDX_utils.c
+++ b/pidx/utils/PIDX_utils.c
@@ -1291,3 +1291,19 @@ PIDX_return_code PIDX_get_datatype_details(PIDX_data_type type, int* values, int
 
     return PIDX_success;
 }
+
+char *replace_str(char *str, char *orig, char *rep)
+{
+  static char buffer[1024];
+  char *p;
+
+  if(!(p = strstr(str, orig)))  // Is 'orig' even in 'str'?
+    return str;
+
+  strncpy(buffer, str, p-str); // Copy characters from 'str' start to 'orig' st$
+  buffer[p-str] = '\0';
+
+  sprintf(buffer+(p-str), "%s%s", rep, p+strlen(orig));
+
+  return buffer;
+}

--- a/pidx/utils/PIDX_utils.h
+++ b/pidx/utils/PIDX_utils.h
@@ -138,4 +138,7 @@ void intersect_grid(Point3D vol_from, Point3D vol_to, Point3D from, Point3D to, 
 
 PIDX_return_code PIDX_get_datatype_details(PIDX_data_type type, int* values, int* bits);
 PIDX_return_code PIDX_decompose_type(PIDX_data_type type, char* base_type, int* ncomps, int* size);
+
+char *replace_str(char *str, char *orig, char *rep);
+
 #endif

--- a/processing/global_idx_merge.c
+++ b/processing/global_idx_merge.c
@@ -587,16 +587,16 @@ int SplitFilename(const char* filename,char* dirname,char* basename)
 int file_initialize_time_step(int current_time_step, char* file_name, char* file_template)
 {
   int N;
-  char dirname[1024], basename[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
   int nbits_blocknumber;
   char *directory_path;
   char *data_set_path;
 
-  data_set_path = malloc(sizeof(*data_set_path) * 1024);
-  memset(data_set_path, 0, sizeof(*data_set_path) * 1024);
+  data_set_path = malloc(sizeof(*data_set_path) * PIDX_FILE_PATH_LENGTH);
+  memset(data_set_path, 0, sizeof(*data_set_path) * PIDX_FILE_PATH_LENGTH);
 
-  directory_path = malloc(sizeof(*directory_path) * 1024);
-  memset(directory_path, 0, sizeof(*directory_path) * 1024);
+  directory_path = malloc(sizeof(*directory_path) * PIDX_FILE_PATH_LENGTH);
+  memset(directory_path, 0, sizeof(*directory_path) * PIDX_FILE_PATH_LENGTH);
 
   strncpy(directory_path, file_name, strlen(file_name) - 4);
 
@@ -707,8 +707,8 @@ int main(int argc, char **argv)
       int hz_index = (int)pow(2, level - 1);
       int file_no = hz_index / (blocks_per_file * samples_per_block);
       int file_count;
-      char existing_file_name[1024];
-      char new_file_name[1024];
+      char existing_file_name[PIDX_FILE_PATH_LENGTH];
+      char new_file_name[PIDX_FILE_PATH_LENGTH];
       int ic = 0;
       if (level <= bits_per_block + log2(blocks_per_file) + 1)
         file_count = 1;
@@ -760,7 +760,7 @@ int main(int argc, char **argv)
           // iterate through all the parttions
           for (ic = 0; ic < idx_count[0] * idx_count[1] * idx_count[2]; ic++)
           {
-            char file_name_skeleton[1024];
+            char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
             strncpy(file_name_skeleton, output_file_name, strlen(output_file_name) - 4);
             file_name_skeleton[strlen(output_file_name) - 4] = '\0';
 

--- a/processing/global_idx_merge.c
+++ b/processing/global_idx_merge.c
@@ -599,7 +599,10 @@ int file_initialize_time_step(int current_time_step, char* file_name, char* file
   memset(directory_path, 0, sizeof(*directory_path) * 1024);
 
   strncpy(directory_path, file_name, strlen(file_name) - 4);
-  sprintf(data_set_path, "%s/time%09d.idx", directory_path, current_time_step);
+
+  char time_template[512];
+  sprintf(time_template, "%%s/%s.idx", file->idx->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, current_time_step);
   free(directory_path);
 
   nbits_blocknumber = (maxh - bits_per_block - 1);

--- a/processing/merge.c
+++ b/processing/merge.c
@@ -556,16 +556,16 @@ static PIDX_return_code IDX_file_open(const char* filename)
 PIDX_return_code file_initialize_time_step(int current_time_step, char* file_name, char* file_template)
 {
   int N;
-  char dirname[1024], basename[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
   int nbits_blocknumber;
   char *directory_path;
   char *data_set_path;
 
-  data_set_path = malloc(sizeof(*data_set_path) * 1024);
-  memset(data_set_path, 0, sizeof(*data_set_path) * 1024);
+  data_set_path = malloc(sizeof(*data_set_path) * PIDX_FILE_PATH_LENGTH);
+  memset(data_set_path, 0, sizeof(*data_set_path) * PIDX_FILE_PATH_LENGTH);
 
-  directory_path = malloc(sizeof(*directory_path) * 1024);
-  memset(directory_path, 0, sizeof(*directory_path) * 1024);
+  directory_path = malloc(sizeof(*directory_path) * PIDX_FILE_PATH_LENGTH);
+  memset(directory_path, 0, sizeof(*directory_path) * PIDX_FILE_PATH_LENGTH);
 
   strncpy(directory_path, file_name, strlen(file_name) - 4);
 
@@ -668,8 +668,8 @@ int main(int argc, char **argv)
       int hz_index = (int)pow(2, level - 1);
       int file_no = hz_index / (blocks_per_file * (int)pow(2, bits_per_block));
       int file_count;
-      char existing_file_name[1024];
-      char new_file_name[1024];
+      char existing_file_name[PIDX_FILE_PATH_LENGTH];
+      char new_file_name[PIDX_FILE_PATH_LENGTH];
       int ic = 0;
       if (level <= bits_per_block + log2(blocks_per_file) + 1)
         file_count = 1;
@@ -708,7 +708,7 @@ int main(int argc, char **argv)
           off_t totl_data_offset = 0;
           for (ic = 0; ic < idx_count[0] * idx_count[1] * idx_count[2]; ic++)
           {
-            char file_name_skeleton[1024];
+            char file_name_skeleton[PIDX_FILE_PATH_LENGTH];
             strncpy(file_name_skeleton, output_file_name, strlen(output_file_name) - 4);
             file_name_skeleton[strlen(output_file_name) - 4] = '\0';
 

--- a/processing/merge.c
+++ b/processing/merge.c
@@ -568,7 +568,10 @@ PIDX_return_code file_initialize_time_step(int current_time_step, char* file_nam
   memset(directory_path, 0, sizeof(*directory_path) * 1024);
 
   strncpy(directory_path, file_name, strlen(file_name) - 4);
-  sprintf(data_set_path, "%s/time%09d.idx", directory_path, current_time_step);
+
+  char time_template[512];
+  sprintf(time_template, "%%s/%s.idx", file->idx->filename_time_template);
+  sprintf(data_set_path, time_template, directory_path, current_time_step);
   free(directory_path);
 
   nbits_blocknumber = (maxh - bits_per_block - 1);

--- a/tools/convert/raw-to-idx.c
+++ b/tools/convert/raw-to-idx.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
   int var;
   int slice = 0;
   int nprocs = 1, rank = 0;
-  char output_file_name[1024];
+  char output_file_name[PIDX_FILE_PATH_LENGTH];
   unsigned long long local_box_offset[3];
 
   // MPI initialization
@@ -328,7 +328,7 @@ static int parse_args(int argc, char **argv)
 
   for (i = 0; i < variable_count; i++)
   {
-    char temp_var_name[1024];
+    char temp_var_name[PIDX_FILE_PATH_LENGTH];
     ret = fscanf(fp, "%s %d", temp_var_name, &values_per_sample[i]);
     if (ret != 2 || ret == EOF)
       return (-1);
@@ -346,7 +346,7 @@ static int parse_args(int argc, char **argv)
 
   for (i = 0; i < time_step_count; i++)
   {
-    char temp_file_name[1024];
+    char temp_file_name[PIDX_FILE_PATH_LENGTH];
     ret = fscanf(fp, "%s", temp_file_name);
     if (ret != 1 || ret == EOF)
       return (-1);

--- a/tools/idx-verify.c
+++ b/tools/idx-verify.c
@@ -184,9 +184,9 @@ int main(int argc, char **argv)
   int global_bounds[PIDX_MAX_DIMENSIONS];
   int compressed_global_bounds[PIDX_MAX_DIMENSIONS];
   int vps[MAX_VARIABLE_COUNT];
-  char variable_name[MAX_VARIABLE_COUNT][1024];
-  char variable_type[MAX_VARIABLE_COUNT][1024];
-  char filename_template[1024];
+  char variable_name[MAX_VARIABLE_COUNT][PIDX_FILE_PATH_LENGTH];
+  char variable_type[MAX_VARIABLE_COUNT][PIDX_FILE_PATH_LENGTH];
+  char filename_template[PIDX_FILE_PATH_LENGTH];
   int variable_count = 0;
   int resolution = 0;
 
@@ -944,18 +944,18 @@ static int generate_file_name(int blocks_per_file, char* filename_template, int 
 static int generate_file_name_template(int maxh, int bits_per_block, char* filename, int current_time_step, char* filename_template)
 {
   int N;
-  char dirname[1024], basename[1024];
+  char dirname[PIDX_FILE_PATH_LENGTH], basename[PIDX_FILE_PATH_LENGTH];
   int nbits_blocknumber;
   char* directory_path;
   char* data_set_path;
 
-  directory_path = (char*) malloc(sizeof (char) * 1024);
+  directory_path = (char*) malloc(sizeof (char) * PIDX_FILE_PATH_LENGTH);
   assert(directory_path);
-  memset(directory_path, 0, sizeof (char) * 1024);
+  memset(directory_path, 0, sizeof (char) * PIDX_FILE_PATH_LENGTH);
 
-  data_set_path = (char*) malloc(sizeof (char) * 1024);
+  data_set_path = (char*) malloc(sizeof (char) * PIDX_FILE_PATH_LENGTH);
   assert(data_set_path);
-  memset(data_set_path, 0, sizeof (char) * 1024);
+  memset(data_set_path, 0, sizeof (char) * PIDX_FILE_PATH_LENGTH);
 
   strncpy(directory_path, filename, strlen(filename) - 4);
   sprintf(data_set_path, "%s/time%09d.idx", directory_path, current_time_step);

--- a/tools/particle-verify.c
+++ b/tools/particle-verify.c
@@ -14,8 +14,8 @@ diff swfile srfile
 int main(int argc, char **argv)
 {
 
-  char write_file[1024];
-  char read_file[1024];
+  char write_file[PIDX_FILE_PATH_LENGTH];
+  char read_file[PIDX_FILE_PATH_LENGTH];
 
   if ( argc != 4 )
   {
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
     return 0;
   }
 
-  char wfile[1024];
+  char wfile[PIDX_FILE_PATH_LENGTH];
   sprintf(wfile, "%s", "wfile");
   int write_file_count = atoi(argv[2]);
   FILE *wfp = fopen(wfile, "w");
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
   fclose(wfp);
 
 
-  char rfile[1024];
+  char rfile[PIDX_FILE_PATH_LENGTH];
   sprintf(rfile, "%s", "rfile");
   int read_file_count = atoi(argv[3]);
   FILE *rfp = fopen(rfile, "w");

--- a/tools/test/test.py
+++ b/tools/test/test.py
@@ -118,7 +118,7 @@ def execute_test(n_cores, n_cores_read, g_box_n, l_box_n, r_box_n, n_ts, n_vars,
     n_tests = 0
 
     generate_vars(n_vars, var_type, var_type)
-    test_str = mpirun+" --oversubscribe -np "+str(n_cores)+" "+write_executable+" -g "+g_box+" -l "+l_box+" -t "+str(n_ts)+" -v "+vars_file+" -f data"
+    test_str = mpirun+" -np "+str(n_cores)+" "+write_executable+" -g "+g_box+" -l "+l_box+" -t "+str(n_ts)+" -v "+vars_file+" -f data"
     #test_str = mpirun+" -np "+str(n_cores)+" "+write_executable+" -g "+g_box+" -l "+l_box+" -r "+r_box+" -t "+str(n_ts)+" -v "+vars_file+" -f data"
     
     if(debug_print>0):
@@ -136,7 +136,7 @@ def execute_test(n_cores, n_cores_read, g_box_n, l_box_n, r_box_n, n_ts, n_vars,
       for vr in range(0, n_vars):
         n_tests = n_tests + 1
 
-        test_str= mpirun+" --oversubscribe -np "+str(n_cores_read)+" "+read_executable+" -g "+g_box+" -l "+l_box_read+" -t "+str(t-1)+" -v "+str(vr)+" -f data"
+        test_str= mpirun+" -np "+str(n_cores_read)+" "+read_executable+" -g "+g_box+" -l "+l_box_read+" -t "+str(t-1)+" -v "+str(vr)+" -f data"
 
         if(debug_print>0):
           print "EXECUTE read:", test_str
@@ -244,6 +244,8 @@ def main(argv):
       travis_mode = 1
       print "----RUNNING IN TRAVIS TEST MODE----"
 
+  if platform.system() == "Darwin":
+    mpirun += " --oversubscribe"
   if profiling > 0:
     os.popen("rm "+prof_file+"*.prof")
 

--- a/tools/test/test.py
+++ b/tools/test/test.py
@@ -118,7 +118,7 @@ def execute_test(n_cores, n_cores_read, g_box_n, l_box_n, r_box_n, n_ts, n_vars,
     n_tests = 0
 
     generate_vars(n_vars, var_type, var_type)
-    test_str = mpirun+" -np "+str(n_cores)+" "+write_executable+" -g "+g_box+" -l "+l_box+" -t "+str(n_ts)+" -v "+vars_file+" -f data"
+    test_str = mpirun+" --oversubscribe -np "+str(n_cores)+" "+write_executable+" -g "+g_box+" -l "+l_box+" -t "+str(n_ts)+" -v "+vars_file+" -f data"
     #test_str = mpirun+" -np "+str(n_cores)+" "+write_executable+" -g "+g_box+" -l "+l_box+" -r "+r_box+" -t "+str(n_ts)+" -v "+vars_file+" -f data"
     
     if(debug_print>0):
@@ -136,7 +136,7 @@ def execute_test(n_cores, n_cores_read, g_box_n, l_box_n, r_box_n, n_ts, n_vars,
       for vr in range(0, n_vars):
         n_tests = n_tests + 1
 
-        test_str= mpirun+" -np "+str(n_cores_read)+" "+read_executable+" -g "+g_box+" -l "+l_box_read+" -t "+str(t-1)+" -v "+str(vr)+" -f data"
+        test_str= mpirun+" --oversubscribe -np "+str(n_cores_read)+" "+read_executable+" -g "+g_box+" -l "+l_box_read+" -t "+str(t-1)+" -v "+str(vr)+" -f data"
 
         if(debug_print>0):
           print "EXECUTE read:", test_str

--- a/tools/test/test.py
+++ b/tools/test/test.py
@@ -71,7 +71,7 @@ profiling = 0
 profile_file_write = "pidx_write.prof"
 profile_file_read = "pidx_read.prof"
 
-vars_file = "VARS"
+vars_file = "./VARS"
 
 def execute_test(n_cores, n_cores_read, g_box_n, l_box_n, r_box_n, n_ts, n_vars, var_type, exec_type):
 
@@ -210,8 +210,8 @@ def main(argv):
   global travis_mode
 
   # defaults
-  n_cores = 8
-  n_cores_read = 8
+  n_cores = 4
+  n_cores_read = 4
 
   n_ts = 1
   n_vars = 1
@@ -244,8 +244,9 @@ def main(argv):
       travis_mode = 1
       print "----RUNNING IN TRAVIS TEST MODE----"
 
-  if platform.system() == "Darwin":
-    mpirun += " --oversubscribe"
+  # if platform.system() == "Darwin":
+  #   mpirun += " --oversubscribe"
+
   if profiling > 0:
     os.popen("rm "+prof_file+"*.prof")
 
@@ -257,7 +258,8 @@ def main(argv):
 
   for var in var_types:
     succ = succ + run_tests(n_cores, n_cores_read, var, n_ts, n_vars, ExecType.idx)
-    os.popen("rm -R data*")
+    if(travis_mode == 0):
+      os.popen("rm -R data*")
 
   if(succ == 0):
     print "***** IDX test SUCCESS *****"
@@ -268,7 +270,8 @@ def main(argv):
   succ = 0
   for var in var_types:
     succ = succ + run_tests(n_cores, n_cores_read, var, n_ts, n_vars, ExecType.partitioned)
-    os.popen("rm -R data*")
+    if(travis_mode == 0):
+      os.popen("rm -R data*")
 
   if(succ == 0):
     print "***** IDX_PARTITIONED test SUCCESS *****"
@@ -276,7 +279,8 @@ def main(argv):
     print "***** IDX_PARTITIONED test FAILED *****"
     failed = 1
 
-  os.popen("rm -R data*")
+  if(travis_mode == 0):
+    os.popen("rm -R data*")
 
   succ = 0
 

--- a/tools/test/test_config.py
+++ b/tools/test/test_config.py
@@ -43,7 +43,7 @@ read_idx_executable = "../../build/examples/idx_read"
 write_compressed_executable = "../../build/examples/idx_write_compressed"
 write_partitioned_executable = "../../build/examples/idx_write_partitioned"
 
-mpirun="mpirun"
+mpirun="mpirun --oversubscribe"
 
 # enable debug prints 
 debug_print=1

--- a/tools/test/test_config.py
+++ b/tools/test/test_config.py
@@ -43,7 +43,7 @@ read_idx_executable = "../../build/examples/idx_read"
 write_compressed_executable = "../../build/examples/idx_write_compressed"
 write_partitioned_executable = "../../build/examples/idx_write_partitioned"
 
-mpirun="mpirun --oversubscribe"
+mpirun="mpirun"
 
 # enable debug prints 
 debug_print=1


### PR DESCRIPTION
Add support for time templates. Files are now read and write using the time template specified in the metadata .idx file