### PR TITLE
file "open" multiplatform

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ branches:
   # whitelist
   only:
     - master
-    - refactor_dtypes
+    - fix_open
 
 #init:
 #  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: c
 branches:
   only:
     - master
-    - fix_time_template
+    - fix_open
 
 cache:
   directories:

--- a/examples/experimental/global_partitioned_idx/single_buffer_global_partitioned_idx_write.c
+++ b/examples/experimental/global_partitioned_idx/single_buffer_global_partitioned_idx_write.c
@@ -388,12 +388,12 @@ static void create_synthetic_simulation_data()
           }
         }
 #else
-#if 1
+#if 0 // TODO check this code, it was enabled but should not
     //float* temp_buffer = malloc(local_box_size[0] * sizeof(*temp_buffer));
     //memset(temp_buffer, 0, local_box_size[0] * sizeof(*temp_buffer));
 
     //
-    int fp = open("magnetic-512-volume.raw", O_RDONLY);
+    int fp = open("magnetic-512-volume.raw", O_RDONLY | O_BINARY);
     //int fp = open("miranda.raw", O_RDONLY);
     int send_o = 0;
     int send_c = 0;

--- a/examples/experimental/global_partitioned_idx/two_var.c
+++ b/examples/experimental/global_partitioned_idx/two_var.c
@@ -597,7 +597,7 @@ static void create_synthetic_simulation_data()
     }
     else
     {
-      int fp = open(raw_file_name, O_RDONLY);
+      int fp = open(raw_file_name, O_RDONLY | O_BINARY);
       int send_o = 0;
       int send_c = 0;
       int recv_o = 0;

--- a/pidx/PIDX_define.h
+++ b/pidx/PIDX_define.h
@@ -45,6 +45,9 @@
 extern "C" {
 #endif
 
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
 
 #define PIDX_CURR_METADATA_VERSION "6.1"
   

--- a/pidx/core/PIDX_generic_rst/PIDX_generic_rst_io.c
+++ b/pidx/core/PIDX_generic_rst/PIDX_generic_rst_io.c
@@ -378,7 +378,7 @@ PIDX_return_code PIDX_generic_rst_buf_aggregated_read(PIDX_generic_rst_id generi
   memset(file_name, 0, PATH_MAX * sizeof(*file_name));
 
   sprintf(file_name, "%s/time%09d/%d_%d", directory_path, generic_rst_id->idx->current_time_step, generic_rst_id->idx_c->grank, g);
-  int fp = open(file_name, O_RDONLY, 0664);
+  int fp = open(file_name, O_RDONLY | O_BINARY, 0664);
   if (fp == -1)
   {
     fprintf(stderr, "[%s] [%d] open() failed while trying to open %s\n", __FILE__, __LINE__, file_name);

--- a/pidx/core/PIDX_generic_rst/PIDX_generic_rst_raw_read.c
+++ b/pidx/core/PIDX_generic_rst/PIDX_generic_rst_raw_read.c
@@ -70,7 +70,7 @@ PIDX_return_code PIDX_generic_rst_forced_raw_read(PIDX_generic_rst_id rst_id)
   free(idx_directory_path);
 
   uint32_t number_cores = 0;
-  int fp = open(size_path, O_RDONLY);
+  int fp = open(size_path, O_RDONLY | O_BINARY);
   ssize_t read_count = pread(fp, &number_cores, sizeof(uint32_t), 0);
   if (read_count != sizeof(uint32_t))
   {
@@ -133,7 +133,7 @@ PIDX_return_code PIDX_generic_rst_forced_raw_read(PIDX_generic_rst_id rst_id)
   uint32_t *offset_buffer = malloc(buffer_read_size);
   memset(offset_buffer, 0, buffer_read_size);
 
-  int fp1 = open(offset_path, O_RDONLY);
+  int fp1 = open(offset_path, O_RDONLY | O_BINARY);
   read_count = pread(fp1, offset_buffer, buffer_read_size, 2 * sizeof(uint32_t));
   if (read_count != buffer_read_size)
   {
@@ -322,7 +322,7 @@ PIDX_return_code PIDX_generic_rst_forced_raw_read(PIDX_generic_rst_id rst_id)
     for (i = 0; i < patch_count; i++)
     {
       sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, patch_grp->source_patch_rank[i], source_patch_id[i]);
-      int fpx = open(file_name, O_RDONLY);
+      int fpx = open(file_name, O_RDONLY | O_BINARY);
 
       pc_index = patch_grp->source_patch_rank[i] * (max_patch_count * temp_max_dim + 1);
       for (d = 0; d < PIDX_MAX_DIMENSIONS; d++)

--- a/pidx/core/PIDX_idx_rst/PIDX_idx_rst_raw_read.c
+++ b/pidx/core/PIDX_idx_rst/PIDX_idx_rst_raw_read.c
@@ -69,7 +69,7 @@ PIDX_return_code PIDX_idx_rst_forced_raw_read(PIDX_idx_rst_id rst_id)
   free(idx_directory_path);
 
   uint32_t number_cores = 0;
-  int fp = open(size_path, O_RDONLY);
+  int fp = open(size_path, O_RDONLY | O_BINARY);
   uint64_t read_count = pread(fp, &number_cores, sizeof(uint32_t), 0);
   if (read_count != sizeof(uint32_t))
   {
@@ -132,7 +132,7 @@ PIDX_return_code PIDX_idx_rst_forced_raw_read(PIDX_idx_rst_id rst_id)
   uint32_t *offset_buffer = malloc(buffer_read_size);
   memset(offset_buffer, 0, buffer_read_size);
 
-  int fp1 = open(offset_path, O_RDONLY);
+  int fp1 = open(offset_path, O_RDONLY | O_BINARY);
   read_count = pread(fp1, offset_buffer, buffer_read_size, 2 * sizeof(uint32_t));
   if (read_count != buffer_read_size)
   {
@@ -321,7 +321,7 @@ PIDX_return_code PIDX_idx_rst_forced_raw_read(PIDX_idx_rst_id rst_id)
     for (i = 0; i < patch_count; i++)
     {
       sprintf(file_name, time_template, directory_path, rst_id->idx_metadata->current_time_step, patch_grp->source_patch[i].rank, source_patch_id[i]);
-      int fpx = open(file_name, O_RDONLY);
+      int fpx = open(file_name, O_RDONLY | O_BINARY);
 
       pc_index = patch_grp->source_patch[i].rank * (max_patch_count * temp_max_dim + 1);
       for (d = 0; d < PIDX_MAX_DIMENSIONS; d++)

--- a/pidx/core/PIDX_raw_rst/PIDX_raw_rst_raw_read.c
+++ b/pidx/core/PIDX_raw_rst/PIDX_raw_rst_raw_read.c
@@ -72,7 +72,7 @@ PIDX_return_code PIDX_raw_rst_forced_raw_read(PIDX_raw_rst_id rst_id)
   free(idx_directory_path);
 
   uint32_t number_cores = 0;
-  int fp = open(size_path, O_RDONLY);
+  int fp = open(size_path, O_RDONLY | O_BINARY);
   if (fp < 0)
   {
     fprintf(stderr, "Error opening file %s Error code %d\n", size_path, errno);
@@ -143,7 +143,7 @@ PIDX_return_code PIDX_raw_rst_forced_raw_read(PIDX_raw_rst_id rst_id)
   uint32_t *offset_buffer = malloc(buffer_read_size);
   memset(offset_buffer, 0, buffer_read_size);
 
-  int fp1 = open(offset_path, O_RDONLY);
+  int fp1 = open(offset_path, O_RDONLY | O_BINARY);
   read_count = pread(fp1, offset_buffer, buffer_read_size, 2 * sizeof(uint32_t));
   if (read_count != buffer_read_size)
   {
@@ -334,7 +334,7 @@ PIDX_return_code PIDX_raw_rst_forced_raw_read(PIDX_raw_rst_id rst_id)
 
         sprintf(file_name, time_template, directory_path, rst_id->idx->current_time_step, patch_grp->source_patch[i].rank, source_patch_id[i]);
 
-        int fpx = open(file_name, O_RDONLY);
+        int fpx = open(file_name, O_RDONLY | O_BINARY);
         other_offset = 0;
         for (int v1 = 0; v1 < start_index; v1++)
         {

--- a/pidx/io/particle/particle_file_per_process_io.c
+++ b/pidx/io/particle/particle_file_per_process_io.c
@@ -177,7 +177,7 @@ PIDX_return_code PIDX_particle_file_per_process_read(PIDX_io file, int svi, int 
     memset(file_name, 0, PATH_MAX * sizeof(*file_name));
     sprintf(file_name, "%s/time%09d/%d_%d", directory_path, file->idx->current_time_step, file->idx_c->simulation_rank, p);
 
-    int fp = open(file_name, O_RDONLY);
+    int fp = open(file_name, O_RDONLY | O_BINARY);
 
     uint64_t data_offset = 0;
     for (int si = svi; si < evi; si++)
@@ -325,7 +325,7 @@ static PIDX_return_code PIDX_meta_data_read(PIDX_io file, int svi)
   free(directory_path);
   if (file->idx_c->simulation_rank == 0 || file->idx_c->simulation_nprocs == 1)
   {
-    int fp = open(file_path, O_RDONLY);
+    int fp = open(file_path, O_RDONLY | O_BINARY);
     uint64_t write_count = pread(fp, global_patch, (file->idx_c->simulation_nprocs * (max_patch_count * (2 * PIDX_MAX_DIMENSIONS + 1) + 1) + 2) * sizeof(double), 0);
     if (write_count != (file->idx_c->simulation_nprocs * (max_patch_count * (2 * PIDX_MAX_DIMENSIONS + 1) + 1) + 2) * sizeof(double))
     {

--- a/pidx/io/particle/particle_vis_read.c
+++ b/pidx/io/particle/particle_vis_read.c
@@ -60,7 +60,7 @@ PIDX_return_code PIDX_particle_vis_read(PIDX_io file, int svi, int evi)
   free(idx_directory_path);
 
   double number_cores = 0;
-  int fp = open(size_path, O_RDONLY);
+  int fp = open(size_path, O_RDONLY | O_BINARY);
   // TODO WILL: This would be a lot easier to follow if we pread into a structure of some kind
   uint64_t read_count = pread(fp, &number_cores, sizeof(double), 0);
   if (read_count != sizeof(double))
@@ -169,7 +169,7 @@ PIDX_return_code PIDX_particle_vis_read(PIDX_io file, int svi, int evi)
         if (intersectNDChunk(local_proc_patch, n_proc_patch))
         {
           sprintf(file_name, time_template, directory_path, file->idx->current_time_step, n, m);
-          int fpx = open(file_name, O_RDONLY);
+          int fpx = open(file_name, O_RDONLY | O_BINARY);
 
           // TODO WILL: For particles we need to rethink how we do this loop, we'll need to
           // check that the particle position is inside our query box, and only then get

--- a/processing/global_idx_merge.c
+++ b/processing/global_idx_merge.c
@@ -786,7 +786,7 @@ int main(int argc, char **argv)
               memset(read_data_buffer[ic], 0, samples_per_block * shared_block_count * bpv[var]/8);
 
               int fd;
-              fd = open(existing_file_name, O_RDONLY);
+              fd = open(existing_file_name, O_RDONLY | O_BINARY);
               if (fd < 0)
               {
                 fprintf(stderr, "[File : %s] [Line : %d] open\n", __FILE__, __LINE__);

--- a/processing/merge.c
+++ b/processing/merge.c
@@ -740,7 +740,7 @@ int main(int argc, char **argv)
               memset(read_data_buffer, 0, (int)pow(2, bits_per_block) * blocks_per_file * bpv[var]);
 
               int fd;
-              fd = open(existing_file_name, O_RDONLY);
+              fd = open(existing_file_name, O_RDONLY | O_BINARY);
               if (fd < 0)
               {
                 fprintf(stderr, "[File : %s] [Line : %d] open\n", __FILE__, __LINE__);

--- a/tools/convert/raw-to-idx.c
+++ b/tools/convert/raw-to-idx.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
 
   for (t = 0; t < time_step_count; t++)
   {
-    int fp = open(file_name[t], O_RDONLY);
+    int fp = open(file_name[t], O_RDONLY | O_BINARY);
     for(var = 0; var < variable_count; var++)
     {
       values_per_sample[var] =  1;

--- a/tools/idx-compare.c
+++ b/tools/idx-compare.c
@@ -84,14 +84,14 @@ int main(int argc, char **argv)
     return 0;
   }
   
-  fd1 = open(argv[1], O_RDONLY); 
+  fd1 = open(argv[1], O_RDONLY | O_BINARY);
   if (fd1 < 0)
   {
     fprintf(stderr, "Invalid input binary file %s\n", argv[1]);
     return(-1);
   }
   
-  fd2 = open (argv[2], O_RDONLY); 
+  fd2 = open (argv[2], O_RDONLY | O_BINARY);
   if (fd2 < 0)
   {
     fprintf(stderr, "Invalid input binary file %s\n", argv[1]);

--- a/tools/idx-dump-header.c
+++ b/tools/idx-dump-header.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
     return 0;
   }
   
-  fd1 = open(argv[1], O_RDONLY); 
+  fd1 = open(argv[1], O_RDONLY | O_BINARY);
   if (fd1 < 0)
   {
     fprintf(stderr, "Invalid input binary file %s\n", argv[1]);

--- a/tools/idx-verify.c
+++ b/tools/idx-verify.c
@@ -547,7 +547,7 @@ int main(int argc, char **argv)
 
         fprintf(stderr, "Parsing File : %s\n", bin_file);
 
-        fd = open(bin_file, O_RDONLY);
+        fd = open(bin_file, O_RDONLY | O_BINARY);
         if (fd < 0)
         {
           fprintf(stderr, "[File : %s] [Line : %d] open %s\n", __FILE__, __LINE__, bin_file);

--- a/tutorial/3_PIDX_Utility_Converters/raw_to_idx.c
+++ b/tutorial/3_PIDX_Utility_Converters/raw_to_idx.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 
   for (t = 0; t < time_step_count; t++)
   {
-    int fp = open(file_name[t], O_RDONLY);
+    int fp = open(file_name[t], O_RDONLY | O_BINARY);
     for(var = 0; var < variable_count; var++)
     {
       values_per_sample[var] =  1;


### PR DESCRIPTION
fixing read "open" call to use always O_RDONLY | O_BINARY, for Windows compatibility.
Tested on windows with Paraview plugin built and Travis and AppVeyor.